### PR TITLE
Merge add, update, and synchronize

### DIFF
--- a/naiserator.go
+++ b/naiserator.go
@@ -25,15 +25,6 @@ type Naiserator struct {
 	AppClient *clientV1Alpha1.Clientset
 }
 
-func setLastSyncedHashAnnotation(app metav1.ObjectMetaAccessor, hash string) {
-	a := app.GetObjectMeta().GetAnnotations()
-	if a == nil {
-		a = make(map[string]string)
-	}
-	a[v1alpha1.LastSyncedHashAnnotation] = hash
-	app.GetObjectMeta().SetAnnotations(a)
-}
-
 // Creates a Kubernetes event.
 func (n *Naiserator) reportEvent(event *corev1.Event) (*corev1.Event, error) {
 	return n.ClientSet.CoreV1().Events(event.Namespace).Create(event)
@@ -69,7 +60,7 @@ func (n *Naiserator) synchronize(previous, app *v1alpha1.Application) error {
 		return fmt.Errorf("while persisting resources to Kubernetes: %s", err)
 	}
 
-	setLastSyncedHashAnnotation(app, hash)
+	app.SetLastSyncedHash(hash)
 	glog.Infof("%s: setting new hash %s", app.Name, hash)
 
 	_, err = n.AppClient.NaiseratorV1alpha1().Applications(app.Namespace).Update(app)

--- a/pkg/apis/naiserator/v1alpha1/defaults.go
+++ b/pkg/apis/naiserator/v1alpha1/defaults.go
@@ -10,6 +10,7 @@ const (
 	DefaultPort     = 80
 )
 
+// ApplyDefaults sets default values where they are missing from an Application spec.
 func ApplyDefaults(app *Application) error {
 	return mergo.Merge(app, getAppDefaults())
 }

--- a/pkg/apis/naiserator/v1alpha1/types.go
+++ b/pkg/apis/naiserator/v1alpha1/types.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const LastSyncedHashAnnotation = "nais.io/lastSyncedHash"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type Application struct {
@@ -114,15 +116,21 @@ func (in Application) Hash() (string, error) {
 	// struct including the relevant fields for
 	// creating a hash of an Application object
 	relevantValues := struct {
-		TypeMeta metav1.TypeMeta
 		AppSpec  ApplicationSpec
 		Labels   map[string]string
 	}{
-		in.TypeMeta,
 		in.Spec,
 		in.Labels,
 	}
 
 	h, err := hash.Hash(relevantValues, nil)
 	return strconv.FormatUint(h, 10), err
+}
+
+func (in *Application) LastSyncedHash() string {
+	a := in.GetAnnotations()
+	if a == nil {
+		a = make(map[string]string)
+	}
+	return a[LastSyncedHashAnnotation]
 }

--- a/pkg/apis/naiserator/v1alpha1/types.go
+++ b/pkg/apis/naiserator/v1alpha1/types.go
@@ -134,3 +134,12 @@ func (in *Application) LastSyncedHash() string {
 	}
 	return a[LastSyncedHashAnnotation]
 }
+
+func (in *Application) SetLastSyncedHash(hash string) {
+	a := in.GetAnnotations()
+	if a == nil {
+		a = make(map[string]string)
+	}
+	a[LastSyncedHashAnnotation] = hash
+}
+

--- a/pkg/resourcecreator/resourcecreator.go
+++ b/pkg/resourcecreator/resourcecreator.go
@@ -10,14 +10,14 @@ import (
 )
 
 // Create takes an Application resource and returns a slice of Kubernetes resources.
-func Create(app *nais.Application) ([]runtime.Object, error) {
+func Create(app *nais.Application) []runtime.Object {
 	return []runtime.Object{
 		Service(app),
 		Deployment(app),
 		ServiceAccount(app),
 		HorizontalPodAutoscaler(app),
 		Ingress(app),
-	}, nil
+	}
 }
 
 func int32p(i int32) *int32 {

--- a/pkg/resourcecreator/resourcecreator_test.go
+++ b/pkg/resourcecreator/resourcecreator_test.go
@@ -17,8 +17,7 @@ import (
 func TestCreateResourceSpecs(t *testing.T) {
 	app := fixtures.Application()
 
-	specs, e := resourcecreator.Create(app)
-	assert.NoError(t, e)
+	specs := resourcecreator.Create(app)
 
 	svc := test.NamedResource(specs, "Service").(*v1.Service)
 	assert.Equal(t, nais.DefaultPort, int(svc.Spec.Ports[0].Port))


### PR DESCRIPTION
This patch introduces a few changes:

* The behavior for `add` and `update` on resources are merged into one.
* `TypeMeta` is removed from the Application hashing function because the contents were inconsistent. @jhrv is this okay?

The result should be that Naiserator does not do needless syncing of existing resources.