### PR TITLE
Inject certificate authority bundles as PEM and JKS to well-known locations

### DIFF
--- a/pkg/resourcecreator/certificateauthority.go
+++ b/pkg/resourcecreator/certificateauthority.go
@@ -1,0 +1,80 @@
+package resourcecreator
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// These constants refer to a ConfigMap that has already been applied to the cluster.
+// The source filenames refer to a PEM bundle and a JKS keystore, respectively.
+const (
+	CA_BUNDLE_CONFIGMAP_NAME      = "ca-bundle"
+	CA_BUNDLE_PEM_SOURCE_FILENAME = "ca-bundle.pem"
+	CA_BUNDLE_JKS_SOURCE_FILENAME = "ca-bundle.jks"
+	NAV_TRUSTSTORE_PATH           = "/etc/ssl/certs/java/cacerts"
+	NAV_TRUSTSTORE_PASSWORD       = "changeme" // The contents in this file is not secret
+)
+
+// The following list was copied from https://golang.org/src/crypto/x509/root_linux.go
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+}
+
+// Mount certificate authority files in all locations expected by different kinds of systems.
+func certificateAuthorityVolumeMounts() []corev1.VolumeMount {
+	vm := make([]corev1.VolumeMount, 0)
+
+	for _, path := range certFiles {
+		vm = append(vm, corev1.VolumeMount{
+			Name:      CA_BUNDLE_CONFIGMAP_NAME,
+			MountPath: path,
+			SubPath:   CA_BUNDLE_PEM_SOURCE_FILENAME,
+		})
+	}
+
+	vm = append(vm, corev1.VolumeMount{
+		Name:      CA_BUNDLE_CONFIGMAP_NAME,
+		MountPath: NAV_TRUSTSTORE_PATH,
+		SubPath:   CA_BUNDLE_JKS_SOURCE_FILENAME,
+	})
+
+	return vm
+}
+
+func certificateAuthorityVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: CA_BUNDLE_CONFIGMAP_NAME,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: CA_BUNDLE_CONFIGMAP_NAME,
+				},
+			},
+		},
+	}
+}
+
+func podSpecCertificateAuthority(podSpec *corev1.PodSpec) *corev1.PodSpec {
+	envs := []corev1.EnvVar{
+		{
+			Name:  "NAV_TRUSTSTORE_PATH",
+			Value: NAV_TRUSTSTORE_PATH,
+		},
+		{
+			Name:  "NAV_TRUSTSTORE_PASSWORD",
+			Value: NAV_TRUSTSTORE_PASSWORD,
+		},
+	}
+
+	mainContainer := &podSpec.Containers[0]
+	mainContainer.Env = append(mainContainer.Env, envs...)
+	mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, certificateAuthorityVolumeMounts()...)
+
+	podSpec.Volumes = append(podSpec.Volumes, certificateAuthorityVolume())
+
+	return podSpec
+}

--- a/pkg/resourcecreator/certificateauthority.go
+++ b/pkg/resourcecreator/certificateauthority.go
@@ -14,8 +14,9 @@ const (
 	NAV_TRUSTSTORE_PASSWORD       = "changeme" // The contents in this file is not secret
 )
 
-// The following list was copied from https://golang.org/src/crypto/x509/root_linux.go
-// Possible certificate files; stop after finding one.
+// The following list was copied from https://golang.org/src/crypto/x509/root_linux.go.
+// CA injection should work out of the box. Implementations differ across systems, so
+// by mounting the certificates in these places, we increase the chances of successful auto-configuration.
 var certFiles = []string{
 	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
 	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
@@ -45,6 +46,7 @@ func certificateAuthorityVolumeMounts() []corev1.VolumeMount {
 	return vm
 }
 
+// Configures a Volume to mount files from the CA bundle ConfigMap.
 func certificateAuthorityVolume() corev1.Volume {
 	return corev1.Volume{
 		Name: CA_BUNDLE_CONFIGMAP_NAME,
@@ -58,6 +60,7 @@ func certificateAuthorityVolume() corev1.Volume {
 	}
 }
 
+// Insert the CA configuration into a PodSpec.
 func podSpecCertificateAuthority(podSpec *corev1.PodSpec) *corev1.PodSpec {
 	envs := []corev1.EnvVar{
 		{

--- a/pkg/resourcecreator/deployment.go
+++ b/pkg/resourcecreator/deployment.go
@@ -62,10 +62,15 @@ func deploymentSpec(app *nais.Application) (*appsv1.DeploymentSpec, error) {
 
 func podSpec(app *nais.Application) (*corev1.PodSpec, error) {
 	var err error
+
 	podSpec := podSpecBase(app)
+
 	if app.Spec.LeaderElection {
 		podSpecLeaderElection(app, podSpec)
 	}
+
+	podSpec = podSpecCertificateAuthority(podSpec)
+
 	if app.Spec.Secrets {
 		podSpec, err = podSpecSecrets(app, podSpec)
 		if err != nil {


### PR DESCRIPTION
A system-wide certificate authority bundle will be mounted in from a ConfigMap, and replaces the following files in the container:

* /etc/ssl/certs/ca-certificates.crt
* /etc/pki/tls/certs/ca-bundle.crt
* /etc/ssl/ca-bundle.pem
* /etc/pki/tls/cacert.pem
* /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

In addition, a Java truststore file will be mounted to `/etc/ssl/certs/java/cacerts`, and its location and password made available through the environment variables `NAV_TRUSTSTORE_PATH` and `NAV_TRUSTSTORE_PASSWORD`.