### PR TITLE
Pass rollout reason annotation to deployment

### DIFF
--- a/pkg/apis/naiserator/v1alpha1/types.go
+++ b/pkg/apis/naiserator/v1alpha1/types.go
@@ -168,11 +168,13 @@ func (in Application) Hash() (string, error) {
 	// struct including the relevant fields for
 	// creating a hash of an Application object
 	relevantValues := struct {
-		AppSpec ApplicationSpec
-		Labels  map[string]string
+		AppSpec     ApplicationSpec
+		Labels      map[string]string
+		Annotations map[string]string
 	}{
 		in.Spec,
 		in.Labels,
+		in.Annotations,
 	}
 
 	h, err := hash.Hash(relevantValues, nil)

--- a/pkg/resourcecreator/deployment.go
+++ b/pkg/resourcecreator/deployment.go
@@ -30,9 +30,11 @@ func Deployment(app *nais.Application, opts ResourceOptions) (*appsv1.Deployment
 
 	objectMeta := app.CreateObjectMeta()
 	if val, ok := app.Annotations["kubernetes.io/change-cause"]; ok {
-		objectMeta.Annotations = map[string]string{
-			"kubernetes.io/change-cause": val,
+		if objectMeta.Annotations == nil {
+			objectMeta.Annotations = make(map[string]string)
 		}
+
+		objectMeta.Annotations["kubernetes.io/change-cause"] = val
 	}
 
 	return &appsv1.Deployment{

--- a/pkg/resourcecreator/deployment.go
+++ b/pkg/resourcecreator/deployment.go
@@ -27,12 +27,20 @@ func Deployment(app *nais.Application, opts ResourceOptions) (*appsv1.Deployment
 	if err != nil {
 		return nil, err
 	}
+
+	objectMeta := app.CreateObjectMeta()
+	if val, ok := app.Annotations["kubernetes.io/change-cause"]; ok {
+		objectMeta.Annotations = map[string]string{
+			"kubernetes.io/change-cause": val,
+		}
+	}
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
 			APIVersion: "apps/v1",
 		},
-		ObjectMeta: app.CreateObjectMeta(),
+		ObjectMeta: objectMeta,
 		Spec:       *spec,
 	}, nil
 }


### PR DESCRIPTION
When the `Application` resource is annotated with the `kubernetes.io/change-cause` annotation, it would be nice to annotate the deployment resource as well. Annotating the deployment resource does not create a new replicaset.

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#checking-rollout-history-of-a-deployment