### PR TITLE
Add support for env var sources

### DIFF
--- a/pkg/apis/naiserator/v1alpha1/application.yaml
+++ b/pkg/apis/naiserator/v1alpha1/application.yaml
@@ -192,6 +192,16 @@ spec:
                         properties:
                           fieldPath:
                             type: string
+                            # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#envvarsource-v1-core
+                            enum:
+                              - "metadata.name"
+                              - "metadata.namespace"
+                              - "metadata.labels"
+                              - "metadata.annotations"
+                              - "spec.nodeName"
+                              - "spec.serviceAccountName"
+                              - "status.hostIP"
+                              - "status.podIP"
             service:
               properties:
                 port:

--- a/pkg/apis/naiserator/v1alpha1/application.yaml
+++ b/pkg/apis/naiserator/v1alpha1/application.yaml
@@ -175,12 +175,23 @@ spec:
                 type: object
                 required:
                   - name
-                  - value
                 properties:
                   name:
                     type: string
                   value:
                     type: string
+                  valueFrom:
+                    type: object
+                    required:
+                      - fieldRef
+                    properties:
+                      fieldRef:
+                        type: object
+                        required:
+                          - fieldPath
+                        properties:
+                          fieldPath:
+                            type: string
             service:
               properties:
                 port:

--- a/pkg/apis/naiserator/v1alpha1/types.go
+++ b/pkg/apis/naiserator/v1alpha1/types.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	hash "github.com/mitchellh/hashstructure"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -68,9 +68,18 @@ type ResourceRequirements struct {
 	Requests ResourceSpec `json:"requests"`
 }
 
+type ObjectFieldSelector struct {
+	FieldPath string `json:"fieldPath"`
+}
+
+type EnvVarSource struct {
+	FieldRef ObjectFieldSelector `json:"fieldRef"`
+}
+
 type EnvVar struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name      string       `json:"name"`
+	Value     string       `json:"value"`
+	ValueFrom EnvVarSource `json:"valueFrom"`
 }
 
 type SecretPath struct {

--- a/pkg/resourcecreator/deployment.go
+++ b/pkg/resourcecreator/deployment.go
@@ -2,6 +2,9 @@ package resourcecreator
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+
 	nais "github.com/nais/naiserator/pkg/apis/naiserator/v1alpha1"
 	"github.com/nais/naiserator/pkg/securelogs"
 	"github.com/nais/naiserator/pkg/vault"
@@ -10,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"os"
-	"strconv"
 )
 
 // default environment variables
@@ -234,7 +235,16 @@ func envVars(app *nais.Application) []corev1.EnvVar {
 	newEnvVars := defaultEnvVars(app)
 
 	for _, envVar := range app.Spec.Env {
-		newEnvVars = append(newEnvVars, corev1.EnvVar{Name: envVar.Name, Value: envVar.Value})
+		if envVar.ValueFrom.FieldRef.FieldPath != "" {
+			newEnvVars = append(newEnvVars, corev1.EnvVar{
+				Name: envVar.Name,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: envVar.ValueFrom.FieldRef.FieldPath},
+				},
+			})
+		} else {
+			newEnvVars = append(newEnvVars, corev1.EnvVar{Name: envVar.Name, Value: envVar.Value})
+		}
 	}
 
 	return newEnvVars

--- a/pkg/resourcecreator/deployment_test.go
+++ b/pkg/resourcecreator/deployment_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/nais/naiserator/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestGetDeployment(t *testing.T) {
@@ -21,11 +21,11 @@ func TestGetDeployment(t *testing.T) {
 	app.Spec.Vault.Enabled = true
 
 	t.Run("Test deployment with vault", test.EnvWrapper(map[string]string{
-		vault.EnvVaultAddr:          "a",
-		vault.EnvVaultAuthPath:      "b",
-		vault.EnvInitContainerImage: "c",
-		vault.EnvVaultKVPath:        "/base/kv",
-		vault.EnvVaultEnabled:       "true",
+		vault.EnvVaultAddr:              "a",
+		vault.EnvVaultAuthPath:          "b",
+		vault.EnvInitContainerImage:     "c",
+		vault.EnvVaultKVPath:            "/base/kv",
+		vault.EnvVaultEnabled:           "true",
 		resourcecreator.NaisClusterName: "some_cluster",
 	}, func(t *testing.T) {
 		opts := resourcecreator.NewResourceOptions()
@@ -224,6 +224,32 @@ func TestEnableSecureLogs(t *testing.T) {
 		spec := deployment.Spec.Template.Spec
 		assert.Len(t, spec.Volumes, 3)
 		assert.Len(t, spec.Containers, 3)
+	})
+}
+
+func TestEnvVarSource(t *testing.T) {
+	t.Run("when valueFrom.fieldRef.fieldPath is set it should be used", func(t *testing.T) {
+		app := fixtures.Application()
+		app.Spec.Env = append(app.Spec.Env, nais.EnvVar{
+			Name: "podIP",
+			ValueFrom: nais.EnvVarSource{
+				FieldRef: nais.ObjectFieldSelector{FieldPath: "status.podIP"},
+			},
+		})
+
+		deployment, err := resourcecreator.Deployment(app, resourcecreator.ResourceOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, deployment)
+
+		appContainer := getContainerByName(deployment.Spec.Template.Spec.Containers, app.Name)
+
+		for _, e := range appContainer.Env {
+			if e.Name == "podIP" {
+				assert.Equal(t, "status.podIP", e.ValueFrom.FieldRef.FieldPath)
+				assert.Equal(t, "", e.Value)
+			}
+		}
+
 	})
 }
 


### PR DESCRIPTION
When setting up an `nais.io/Application` for kafka-connect I discovered that its only possible to use `value` in the `spec.env` map. kafka-connect needs the pod ip as an env variable that it will communicate to the other nodes in the kafka-connect cluster.

This can be solved by supporting `valueFrom.fieldRef.fieldPath`.

One caveat with this change is that we no longer require `value`, so if both `value` and `valueFrom` is missing the deployment will fail. Its not possible to use `oneOf` in the OpenAPI spec implemented in k8s: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/

> The following fields are removed as they aren’t supported by OpenAPI v2 (in future versions OpenAPI v3 will be used without these restrictions)
> The fields oneOf, anyOf and not are removed

We could still require `value` in the schema and expect the user to set it to an empty string if they want to utilize `valueFrom`, not sure what is best.

See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#envvarsource-v1-core