### PR TITLE
Wrote tests for istio rbac

### DIFF
--- a/pkg/resourcecreator/istio.go
+++ b/pkg/resourcecreator/istio.go
@@ -53,13 +53,13 @@ func getDefaultServiceRoleBinding(appName string, namespace string) istio_crd.Se
 }
 
 func ServiceRoleBinding(app *nais.Application) (*istio_crd.ServiceRoleBinding, error) {
-	if !app.Spec.AccessPolicy.Ingress.AllowAll {
-		if len(app.Spec.AccessPolicy.Ingress.Rules) > 0 {
-			return nil, fmt.Errorf("cannot have ingress rules with allowAll = True")
-		}
-		return nil, nil
+	if app.Spec.AccessPolicy.Ingress.AllowAll && len(app.Spec.AccessPolicy.Ingress.Rules) > 0 {
+		return nil, fmt.Errorf("cannot have access policy rules with allowAll = True")
 	}
 
+	if !app.Spec.AccessPolicy.Ingress.AllowAll && len(app.Spec.AccessPolicy.Ingress.Rules) == 0 {
+		return nil, nil
+	}
 	return &istio_crd.ServiceRoleBinding{
 		TypeMeta: k8s_meta.TypeMeta{
 			Kind:       "ServiceRoleBinding",
@@ -71,10 +71,11 @@ func ServiceRoleBinding(app *nais.Application) (*istio_crd.ServiceRoleBinding, e
 }
 
 func ServiceRole(app *nais.Application) (*istio_crd.ServiceRole, error) {
-	if !app.Spec.AccessPolicy.Ingress.AllowAll {
-		if len(app.Spec.AccessPolicy.Ingress.Rules) > 0 {
-			return nil, fmt.Errorf("cannot have ingress rules with allowAll = True")
-		}
+	if app.Spec.AccessPolicy.Ingress.AllowAll && len(app.Spec.AccessPolicy.Ingress.Rules) > 0 {
+		return nil, fmt.Errorf("cannot have access policy rules with allowAll = True")
+	}
+
+	if !app.Spec.AccessPolicy.Ingress.AllowAll && len(app.Spec.AccessPolicy.Ingress.Rules) == 0 {
 		return nil, nil
 	}
 

--- a/pkg/resourcecreator/istio_test.go
+++ b/pkg/resourcecreator/istio_test.go
@@ -1,24 +1,51 @@
-package resourcecreator
+package resourcecreator_test
 
 import (
-	"encoding/json"
+	"github.com/nais/naiserator/pkg/apis/rbac.istio.io/v1alpha1"
 	"testing"
 
 	nais "github.com/nais/naiserator/pkg/apis/naiserator/v1alpha1"
+
+	"github.com/nais/naiserator/pkg/resourcecreator"
 	"github.com/nais/naiserator/pkg/test/fixtures"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIstio(t *testing.T) {
-	t.Run("", func(t *testing.T) {
+	t.Run("no service role resource created and no error with access policy rules is defined and allow all is false", func(t *testing.T) {
 		app := fixtures.MinimalApplication()
 		err := nais.ApplyDefaults(app)
 		assert.NoError(t, err)
 
-		obj, err := ServiceRole(app)
+		serviceRole, err := resourcecreator.ServiceRole(app)
 
-		some, err := json.Marshal(obj)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, string(some))
+		assert.Nil(t, serviceRole)
 	})
+
+	t.Run("access policy rules defined when allow all is false throws an error", func(t *testing.T) {
+		app := fixtures.MinimalApplication()
+		err := nais.ApplyDefaults(app)
+		assert.NoError(t, err)
+		app.Spec.AccessPolicy.Ingress.Rules = []nais.AccessPolicyGressRule{{"a", ""}}
+
+		serviceRole, err := resourcecreator.ServiceRole(app)
+
+		assert.Error(t, err)
+		assert.Nil(t, serviceRole)
+	})
+
+	t.Run("access policy with allow all returns servicerole with * as access rule", func(t *testing.T) {
+		app := fixtures.MinimalApplication()
+		err := nais.ApplyDefaults(app)
+		assert.NoError(t, err)
+		app.Spec.AccessPolicy.Ingress.AllowAll = true
+
+		serviceRole, err := resourcecreator.ServiceRole(app)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, serviceRole)
+		assert.Equal(t, []*v1alpha1.AccessRule([]*v1alpha1.AccessRule{{[]string{"*"}, []string{"*"}}}), serviceRole.Spec.Rules)
+	})
+
 }

--- a/pkg/resourcecreator/istio_test.go
+++ b/pkg/resourcecreator/istio_test.go
@@ -117,7 +117,9 @@ func TestIstio(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, serviceRoleBinding)
-		assert.Equal(t, []*v1alpha1.Subject([]*v1alpha1.Subject{{User: fmt.Sprintf("cluster.local/ns/%s/sa/%s", app.Namespace, otherApplication)}}), serviceRoleBinding.Spec.Subjects)
+		s := fmt.Sprintf("cluster.local/ns/%s/sa/%s", app.Namespace, otherApplication)
+		assert.Equal(t, s, serviceRoleBinding.Spec.Subjects[0].User)
+		assert.Len(t, serviceRoleBinding.Spec.Subjects, 1)
 	})
 
 }


### PR DESCRIPTION
Corrected some implementations on ServiceRole and ServiceRoleBinding:
- ServiceRole and -Binding now throws error if `Spec.AccessPolicy.Ingress.AllowAll` is set to true while there is defined access policy ingress rules.
- The created subjects of ServiceRoleBinding has the namespace defined in the rule, if set.
- The subject of ServiceRoleBinding is set to * if `allowAll` is true.