### PR TITLE
Support Ingress-like behavior with access policies turned on

### DIFF
--- a/pkg/resourcecreator/istio_test.go
+++ b/pkg/resourcecreator/istio_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	nais "github.com/nais/naiserator/pkg/apis/naiserator/v1alpha1"
-
 	"github.com/nais/naiserator/pkg/resourcecreator"
 	"github.com/nais/naiserator/pkg/test/fixtures"
 	"github.com/stretchr/testify/assert"
@@ -126,6 +125,51 @@ func TestIstio(t *testing.T) {
 		user := fmt.Sprintf("cluster.local/ns/%s/sa/%s", app.Namespace, otherApplication)
 		assert.Equal(t, user, serviceRoleBinding.Spec.Subjects[0].User)
 		assert.Len(t, serviceRoleBinding.Spec.Subjects, 1)
+	})
+
+	t.Run("specifying ingresses allows traffic from istio ingress gateway", func(t *testing.T) {
+		app := fixtures.MinimalApplication()
+		app.Spec.AccessPolicy.Ingress.AllowAll = true
+		app.Spec.Ingresses = []string{
+			"https://gief.api.plz",
+		}
+		err := nais.ApplyDefaults(app)
+		assert.NoError(t, err)
+
+		serviceRole, err := resourcecreator.ServiceRole(app)
+		assert.NoError(t, err)
+		assert.NotNil(t, serviceRole)
+
+		for _, rule := range serviceRole.Spec.Rules {
+			assert.Contains(t, rule.Services, "istio-ingressgateway.istio-system.svc.cluster.local")
+		}
+
+		serviceRoleBinding, err := resourcecreator.ServiceRoleBinding(app)
+		assert.NoError(t, err)
+		assert.NotNil(t, serviceRoleBinding)
+
+		assert.Contains(t, serviceRoleBinding.Spec.Subjects, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+	})
+
+	t.Run("omitting ingresses denies traffic from istio ingress gateway", func(t *testing.T) {
+		app := fixtures.MinimalApplication()
+		app.Spec.AccessPolicy.Ingress.AllowAll = true
+		err := nais.ApplyDefaults(app)
+		assert.NoError(t, err)
+
+		serviceRole, err := resourcecreator.ServiceRole(app)
+		assert.NoError(t, err)
+		assert.NotNil(t, serviceRole)
+
+		for _, rule := range serviceRole.Spec.Rules {
+			assert.NotContains(t, rule.Services, "istio-ingressgateway.istio-system.svc.cluster.local")
+		}
+
+		serviceRoleBinding, err := resourcecreator.ServiceRoleBinding(app)
+		assert.NoError(t, err)
+		assert.NotNil(t, serviceRoleBinding)
+
+		assert.NotContains(t, serviceRoleBinding.Spec.Subjects, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
 	})
 
 }

--- a/pkg/resourcecreator/istio_test.go
+++ b/pkg/resourcecreator/istio_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	nais "github.com/nais/naiserator/pkg/apis/naiserator/v1alpha1"
+	rbac_istio_io_v1alpha1 "github.com/nais/naiserator/pkg/apis/rbac.istio.io/v1alpha1"
 	"github.com/nais/naiserator/pkg/resourcecreator"
 	"github.com/nais/naiserator/pkg/test/fixtures"
 	"github.com/stretchr/testify/assert"
@@ -147,8 +148,11 @@ func TestIstio(t *testing.T) {
 		serviceRoleBinding, err := resourcecreator.ServiceRoleBinding(app)
 		assert.NoError(t, err)
 		assert.NotNil(t, serviceRoleBinding)
+		subject := rbac_istio_io_v1alpha1.Subject{
+			User: "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account",
+		}
 
-		assert.Contains(t, serviceRoleBinding.Spec.Subjects, "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+		assert.Contains(t, serviceRoleBinding.Spec.Subjects, &subject)
 	})
 
 	t.Run("omitting ingresses denies traffic from istio ingress gateway", func(t *testing.T) {

--- a/pkg/resourcecreator/networkpolicy.go
+++ b/pkg/resourcecreator/networkpolicy.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func addNetworkPolicyGressRules(rules []nais.AccessPolicyGressRule) (networkPolicy []networkingv1.NetworkPolicyPeer) {
+func networkPolicyGressRules(rules []nais.AccessPolicyGressRule) (networkPolicy []networkingv1.NetworkPolicyPeer) {
 	for _, gress := range rules {
 		networkPolicyPeer := networkingv1.NetworkPolicyPeer{
 			PodSelector: &metav1.LabelSelector{
@@ -31,19 +31,38 @@ func addNetworkPolicyGressRules(rules []nais.AccessPolicyGressRule) (networkPoli
 }
 
 func ingressPolicy(app *nais.Application) []networkingv1.NetworkPolicyIngressRule {
+	rules := make([]networkingv1.NetworkPolicyIngressRule, 0)
+
 	if app.Spec.AccessPolicy.Ingress.AllowAll {
-		return []networkingv1.NetworkPolicyIngressRule{{}}
+		rules = append(rules, networkingv1.NetworkPolicyIngressRule{
+
+		})
+	} else if len(app.Spec.AccessPolicy.Ingress.Rules) > 0 {
+		rules = append(rules, networkingv1.NetworkPolicyIngressRule{
+			From: networkPolicyGressRules(app.Spec.AccessPolicy.Ingress.Rules),
+		})
 	}
 
-	if len(app.Spec.AccessPolicy.Ingress.Rules) > 0 {
-		return []networkingv1.NetworkPolicyIngressRule{
-			{
-				From: addNetworkPolicyGressRules(app.Spec.AccessPolicy.Ingress.Rules),
+	if len(app.Spec.Ingresses) > 0 {
+		rules = append(rules, networkingv1.NetworkPolicyIngressRule{
+			From: []networkingv1.NetworkPolicyPeer{
+				{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"istio": "ingressgateway",
+						},
+					},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"name": "istio-system",
+						},
+					},
+				},
 			},
-		}
+		})
 	}
 
-	return []networkingv1.NetworkPolicyIngressRule{}
+	return rules
 }
 
 func egressPolicy(app *nais.Application) []networkingv1.NetworkPolicyEgressRule {
@@ -54,7 +73,7 @@ func egressPolicy(app *nais.Application) []networkingv1.NetworkPolicyEgressRule 
 	if len(app.Spec.AccessPolicy.Egress.Rules) > 0 {
 		return []networkingv1.NetworkPolicyEgressRule{
 			{
-				To: addNetworkPolicyGressRules(app.Spec.AccessPolicy.Egress.Rules),
+				To: networkPolicyGressRules(app.Spec.AccessPolicy.Egress.Rules),
 			},
 		}
 	}

--- a/pkg/resourcecreator/networkpolicy.go
+++ b/pkg/resourcecreator/networkpolicy.go
@@ -30,36 +30,36 @@ func addNetworkPolicyGressRules(rules []nais.AccessPolicyGressRule) (networkPoli
 	return
 }
 
-func ingressPolicy(app *nais.Application) *[]networkingv1.NetworkPolicyIngressRule {
+func ingressPolicy(app *nais.Application) []networkingv1.NetworkPolicyIngressRule {
 	if app.Spec.AccessPolicy.Ingress.AllowAll {
-		return &[]networkingv1.NetworkPolicyIngressRule{{}}
+		return []networkingv1.NetworkPolicyIngressRule{{}}
 	}
 
 	if len(app.Spec.AccessPolicy.Ingress.Rules) > 0 {
-		return &[]networkingv1.NetworkPolicyIngressRule{
+		return []networkingv1.NetworkPolicyIngressRule{
 			{
 				From: addNetworkPolicyGressRules(app.Spec.AccessPolicy.Ingress.Rules),
 			},
 		}
 	}
 
-	return &[]networkingv1.NetworkPolicyIngressRule{}
+	return []networkingv1.NetworkPolicyIngressRule{}
 }
 
-func egressPolicy(app *nais.Application) *[]networkingv1.NetworkPolicyEgressRule {
+func egressPolicy(app *nais.Application) []networkingv1.NetworkPolicyEgressRule {
 	if app.Spec.AccessPolicy.Egress.AllowAll {
-		return &[]networkingv1.NetworkPolicyEgressRule{{}}
+		return []networkingv1.NetworkPolicyEgressRule{{}}
 	}
 
 	if len(app.Spec.AccessPolicy.Egress.Rules) > 0 {
-		return &[]networkingv1.NetworkPolicyEgressRule{
+		return []networkingv1.NetworkPolicyEgressRule{
 			{
 				To: addNetworkPolicyGressRules(app.Spec.AccessPolicy.Egress.Rules),
 			},
 		}
 	}
 
-	return &[]networkingv1.NetworkPolicyEgressRule{}
+	return []networkingv1.NetworkPolicyEgressRule{}
 }
 
 func networkPolicySpec(app *nais.Application) *networkingv1.NetworkPolicySpec {
@@ -73,8 +73,8 @@ func networkPolicySpec(app *nais.Application) *networkingv1.NetworkPolicySpec {
 			networkingv1.PolicyTypeIngress,
 			networkingv1.PolicyTypeEgress,
 		},
-		Ingress: *ingressPolicy(app),
-		Egress:  *egressPolicy(app),
+		Ingress: ingressPolicy(app),
+		Egress:  egressPolicy(app),
 	}
 
 }

--- a/pkg/resourcecreator/networkpolicy_test.go
+++ b/pkg/resourcecreator/networkpolicy_test.go
@@ -1,9 +1,10 @@
-package resourcecreator
+package resourcecreator_test
 
 import (
 	"testing"
 
 	nais "github.com/nais/naiserator/pkg/apis/naiserator/v1alpha1"
+	"github.com/nais/naiserator/pkg/resourcecreator"
 	"github.com/nais/naiserator/pkg/test/fixtures"
 	"github.com/stretchr/testify/assert"
 	networking "k8s.io/api/networking/v1"
@@ -18,7 +19,7 @@ func TestNetworkPolicy(t *testing.T) {
 		err := nais.ApplyDefaults(app)
 		assert.NoError(t, err)
 
-		networkPolicy := NetworkPolicy(app)
+		networkPolicy := resourcecreator.NetworkPolicy(app)
 
 		assert.Empty(t, networkPolicy.Spec.Egress[0].To)
 		assert.Empty(t, networkPolicy.Spec.Egress[0].Ports)
@@ -32,7 +33,7 @@ func TestNetworkPolicy(t *testing.T) {
 		err := nais.ApplyDefaults(app)
 		assert.NoError(t, err)
 
-		networkPolicy := NetworkPolicy(app)
+		networkPolicy := resourcecreator.NetworkPolicy(app)
 
 		assert.Equal(t, []networking.NetworkPolicyEgressRule{}, networkPolicy.Spec.Egress)
 		assert.Equal(t, []networking.NetworkPolicyIngressRule{}, networkPolicy.Spec.Ingress)
@@ -44,7 +45,7 @@ func TestNetworkPolicy(t *testing.T) {
 		err := nais.ApplyDefaults(app)
 		assert.NoError(t, err)
 
-		networkPolicy := NetworkPolicy(app)
+		networkPolicy := resourcecreator.NetworkPolicy(app)
 
 		matchLabels := map[string]string{
 			"app": accessPolicyApp,

--- a/pkg/resourcecreator/resourcecreator.go
+++ b/pkg/resourcecreator/resourcecreator.go
@@ -35,13 +35,24 @@ func Create(app *nais.Application, resourceOptions ResourceOptions) ([]runtime.O
 		if serviceRole != nil {
 			objects = append(objects, serviceRole)
 		}
+
 		serviceRoleBinding, err := ServiceRoleBinding(app)
 		if err != nil {
 			return nil, fmt.Errorf("while creating access policies: %s", err)
 		}
-
 		if serviceRoleBinding != nil {
 			objects = append(objects, serviceRoleBinding)
+		}
+
+	} else {
+
+		ingress, err := Ingress(app)
+		if err != nil {
+			return nil, fmt.Errorf("while creating ingress: %s", err)
+		}
+		if ingress != nil {
+			// the application might have no ingresses, in which case nil will be returned.
+			objects = append(objects, ingress)
 		}
 	}
 
@@ -50,15 +61,6 @@ func Create(app *nais.Application, resourceOptions ResourceOptions) ([]runtime.O
 		return nil, fmt.Errorf("while creating deployment: %s", err)
 	}
 	objects = append(objects, deployment)
-
-	ingress, err := Ingress(app)
-	if err != nil {
-		return nil, fmt.Errorf("while creating ingress: %s", err)
-	}
-	if ingress != nil {
-		// the application might have no ingresses, in which case nil will be returned.
-		objects = append(objects, ingress)
-	}
 
 	return objects, nil
 }

--- a/pkg/resourcecreator/resourcecreator.go
+++ b/pkg/resourcecreator/resourcecreator.go
@@ -26,7 +26,11 @@ func Create(app *nais.Application, resourceOptions ResourceOptions) ([]runtime.O
 
 	if resourceOptions.AccessPolicy {
 		objects = append(objects, NetworkPolicy(app))
-		objects = append(objects, VirtualService(app))
+
+		vs := VirtualService(app)
+		if vs != nil {
+			objects = append(objects, vs)
+		}
 
 		serviceRole, err := ServiceRole(app)
 		if err != nil {

--- a/pkg/resourcecreator/resourcecreator_test.go
+++ b/pkg/resourcecreator/resourcecreator_test.go
@@ -160,7 +160,7 @@ func TestCreate(t *testing.T) {
 		assert.NoError(t, err)
 
 		objects := getRealObjects(resources)
-		assert.NotNil(t, objects.virtualService)
+		assert.Nil(t, objects.virtualService)
 		assert.Nil(t, objects.serviceRoleBinding)
 		assert.Nil(t, objects.serviceRole)
 		assert.NotNil(t, objects.networkPolicy)
@@ -170,6 +170,7 @@ func TestCreate(t *testing.T) {
 		app := fixtures.MinimalApplication()
 		opts := resourcecreator.NewResourceOptions()
 		opts.AccessPolicy = true
+		app.Spec.Ingresses = []string{"https://foo.bar"}
 		app.Spec.AccessPolicy.Ingress.AllowAll = true
 
 		err := nais.ApplyDefaults(app)

--- a/pkg/resourcecreator/virtualservice.go
+++ b/pkg/resourcecreator/virtualservice.go
@@ -17,6 +17,10 @@ const (
 )
 
 func VirtualService(app *nais.Application) *istio.VirtualService {
+	if len(app.Spec.Ingresses) == 0 {
+		return nil
+	}
+
 	hosts := make([]string, len(app.Spec.Ingresses))
 
 	for i := range app.Spec.Ingresses {


### PR DESCRIPTION
This patch makes sure that `ServiceRole`, `ServiceRoleBinding`, `VirtualService` and `NetworkPolicy` objects implement the functionality required to have a working Ingress.