### PR TITLE
Restrict prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It is no longer needed to have the project checked out in your `$GOPATH`.
 
 ```
 kubectl apply -f pkg/apis/naiserator/v1alpha1/application.yaml
-kubectl apply -f examples/app.yaml
+kubectl apply -f examples/nais.yaml
 make local
 ```
 

--- a/examples/nais-max.yaml
+++ b/examples/nais-max.yaml
@@ -79,3 +79,22 @@ spec:
       allowAll: false # optional, opens up for all outbound access
       rules:
         - www.external-application.com
+
+  skipCaBundle: false # optional, if true we don't mount any CA Bundles into the application
+  accessPolicy:
+    inbound:
+      allowIngressTraffic: true # configures access from istio-ingressgateway in istio-system namespace
+      rules:
+        - application: app1 # allows access from application a in same namespace
+        - application: app2
+          namespace: q1 # optional, defaults to 'metadata.namespace'
+        - application: app3
+          namespace: t1
+        - application: * # we should consider if this is actually needed, or if rules should be explicit
+          namespace: t1 # opens up for all inbound access from 't1' namespace
+    outbound:
+      rules: # is this needed?
+        - application: app4
+          namespace: ... 
+      external: # cluster external hosts application needs to access
+        - host: www.external-application.com

--- a/examples/nais.yaml
+++ b/examples/nais.yaml
@@ -6,9 +6,8 @@ metadata:
   labels:
     team: aura
 spec:
-  skipCaBundle: true
-  image: navikt/nais-testapp:local
-  port: 8080
+  image: navikt/nais-testapp:latest
+  port: 8080 
   liveness:
     path: /isalive
   readiness:

--- a/pkg/apis/naiserator/v1alpha1/meta.go
+++ b/pkg/apis/naiserator/v1alpha1/meta.go
@@ -15,6 +15,12 @@ func (in *Application) CreateObjectMeta() metav1.ObjectMeta {
 	}
 }
 
+func (in *Application) CreateObjectMetaWithName(name string) metav1.ObjectMeta {
+	m := in.CreateObjectMeta()
+	m.Name = name
+	return m
+}
+
 func (in *Application) OwnerReferences(app *Application) []metav1.OwnerReference {
 	return []metav1.OwnerReference{app.GetOwnerReference()}
 }

--- a/pkg/apis/rbac.istio.io/v1alpha1/types.go
+++ b/pkg/apis/rbac.istio.io/v1alpha1/types.go
@@ -28,6 +28,7 @@ type ServiceRoleSpec struct {
 type AccessRule struct {
 	Services []string `json:"services"`
 	Methods  []string `json:"methods"`
+	Paths 	 []string `json:"Paths"`
 }
 
 // +genclient

--- a/pkg/apis/rbac.istio.io/v1alpha1/types.go
+++ b/pkg/apis/rbac.istio.io/v1alpha1/types.go
@@ -28,7 +28,7 @@ type ServiceRoleSpec struct {
 type AccessRule struct {
 	Services []string `json:"services"`
 	Methods  []string `json:"methods"`
-	Paths 	 []string `json:"Paths"`
+	Paths    []string `json:"paths"`
 }
 
 // +genclient

--- a/pkg/resourcecreator/istio.go
+++ b/pkg/resourcecreator/istio.go
@@ -126,23 +126,24 @@ func ServiceRolePrometheus(app *nais.Application) (serviceRolePrometheus *istio_
 		return nil, nil
 	}
 
-	serviceRolePrometheus, err = ServiceRole(app)
-	if err != nil || serviceRolePrometheus == nil {
-		return nil, err
-	}
-
-	serviceRolePrometheus.ObjectMeta.Name += "-prometheus"
+	name := fmt.Sprintf("%s-prometheus", app.Name)
 
 	servicePath := fmt.Sprintf("%s.%s.svc.cluster.local", app.Name, app.Namespace)
 
-	serviceRolePrometheus.Spec.Rules = []*istio_crd.AccessRule{
-		{
-			Methods:  []string{"GET"},
-			Services: []string{servicePath},
-			Paths:    []string{app.Spec.Prometheus.Path},
+	return &istio_crd.ServiceRole{
+		TypeMeta: k8s_meta.TypeMeta{
+			Kind:       "ServiceRole",
+			APIVersion: IstioAPIVersion,
 		},
-	}
-
-	return
-
+		ObjectMeta: app.CreateObjectMetaWithName(name),
+		Spec: istio_crd.ServiceRoleSpec{
+			Rules: []*istio_crd.AccessRule{
+				{
+					Methods:  []string{"GET"},
+					Services: []string{servicePath},
+					Paths:    []string{app.Spec.Prometheus.Path},
+				},
+			},
+		},
+	}, nil
 }

--- a/pkg/resourcecreator/istio.go
+++ b/pkg/resourcecreator/istio.go
@@ -96,7 +96,7 @@ func ServiceRoleBindingPrometheus(app *nais.Application) ( serviceRoleBindingPro
 	}
 
 	serviceRoleBindingPrometheus, err = ServiceRoleBinding(app)
-	if err != nil || (err == nil && serviceRoleBindingPrometheus == nil )  {
+	if err != nil || serviceRoleBindingPrometheus == nil  {
 		return nil, err
 	}
 
@@ -104,11 +104,9 @@ func ServiceRoleBindingPrometheus(app *nais.Application) ( serviceRoleBindingPro
 
 	serviceRoleBindingPrometheus.Spec.RoleRef.Name = serviceRoleBindingPrometheus.ObjectMeta.Name
 
-	serviceRoleBindingPrometheus.Spec = istio_crd.ServiceRoleBindingSpec{
-		Subjects: []*istio_crd.Subject{
-			{
-				User: fmt.Sprintf("cluster.local/ns/%s/sa/%s", IstioNamespace, IstioPrometheusServiceAccount),
-			},
+	serviceRoleBindingPrometheus.Spec.Subjects = []*istio_crd.Subject{
+		{
+			User: fmt.Sprintf("cluster.local/ns/%s/sa/%s", IstioNamespace, IstioPrometheusServiceAccount),
 		},
 	}
 
@@ -151,7 +149,7 @@ func ServiceRolePrometheus(app *nais.Application) (serviceRolePrometheus *istio_
 	}
 
 	serviceRolePrometheus, err = ServiceRole(app)
-	if err != nil || (err == nil && serviceRolePrometheus == nil) {
+	if err != nil || serviceRolePrometheus == nil {
 		return nil, err
 	}
 

--- a/pkg/resourcecreator/istio.go
+++ b/pkg/resourcecreator/istio.go
@@ -90,13 +90,13 @@ func ServiceRoleBinding(app *nais.Application) (*istio_crd.ServiceRoleBinding, e
 	}, nil
 }
 
-func ServiceRoleBindingPrometheus(app *nais.Application) ( serviceRoleBindingPrometheus *istio_crd.ServiceRoleBinding, err error) {
+func ServiceRoleBindingPrometheus(app *nais.Application) (serviceRoleBindingPrometheus *istio_crd.ServiceRoleBinding, err error) {
 	if !app.Spec.Prometheus.Enabled {
 		return nil, nil
 	}
 
 	serviceRoleBindingPrometheus, err = ServiceRoleBinding(app)
-	if err != nil || serviceRoleBindingPrometheus == nil  {
+	if err != nil || serviceRoleBindingPrometheus == nil {
 		return nil, err
 	}
 
@@ -112,7 +112,6 @@ func ServiceRoleBindingPrometheus(app *nais.Application) ( serviceRoleBindingPro
 
 	return
 }
-
 
 func ServiceRole(app *nais.Application) (*istio_crd.ServiceRole, error) {
 	if app.Spec.AccessPolicy.Ingress.AllowAll && len(app.Spec.AccessPolicy.Ingress.Rules) > 0 {
@@ -136,7 +135,7 @@ func ServiceRole(app *nais.Application) (*istio_crd.ServiceRole, error) {
 				{
 					Methods:  []string{"*"},
 					Services: []string{servicePath},
-					Paths: 	  []string{"*"},
+					Paths:    []string{"*"},
 				},
 			},
 		},
@@ -159,9 +158,9 @@ func ServiceRolePrometheus(app *nais.Application) (serviceRolePrometheus *istio_
 
 	serviceRolePrometheus.Spec.Rules = []*istio_crd.AccessRule{
 		{
-			Methods: []string{"GET"},
+			Methods:  []string{"GET"},
 			Services: []string{servicePath},
-			Paths: []string{app.Spec.Prometheus.Path},
+			Paths:    []string{app.Spec.Prometheus.Path},
 		},
 	}
 

--- a/pkg/resourcecreator/istio_test.go
+++ b/pkg/resourcecreator/istio_test.go
@@ -138,7 +138,7 @@ func TestIstio(t *testing.T) {
 
 		serviceRolePrometheus, err := resourcecreator.ServiceRolePrometheus(app)
 		assert.NoError(t, err)
-		assert.Nil(t,serviceRolePrometheus)
+		assert.Nil(t, serviceRolePrometheus)
 
 		serviceRoleBindingPrometheus, err := resourcecreator.ServiceRoleBindingPrometheus(app)
 		assert.NoError(t, err)
@@ -153,16 +153,15 @@ func TestIstio(t *testing.T) {
 		err := nais.ApplyDefaults(app)
 		assert.NoError(t, err)
 
-
 		serviceRolePrometheus, err := resourcecreator.ServiceRolePrometheus(app)
 		assert.NoError(t, err)
-		assert.NotNil(t,serviceRolePrometheus)
+		assert.NotNil(t, serviceRolePrometheus)
 
 		serviceRoleBindingPrometheus, err := resourcecreator.ServiceRoleBindingPrometheus(app)
 		assert.NoError(t, err)
 		assert.NotNil(t, serviceRoleBindingPrometheus)
 
-		assert.Equal(t,serviceRolePrometheus.ObjectMeta.Name, serviceRoleBindingPrometheus.ObjectMeta.Name)
+		assert.Equal(t, serviceRolePrometheus.ObjectMeta.Name, serviceRoleBindingPrometheus.ObjectMeta.Name)
 	})
 
 }

--- a/pkg/resourcecreator/istio_test.go
+++ b/pkg/resourcecreator/istio_test.go
@@ -130,20 +130,39 @@ func TestIstio(t *testing.T) {
 		assert.NotContains(t, serviceRoleBinding.Spec.Subjects, &subject)
 	})
 
-	t.Run("prometheus enabled adds istio system default service account to servicerolebinding", func(t *testing.T) {
+	t.Run("no service role and no service role binding created for prometheus, when disabled ", func(t *testing.T) {
 		app := fixtures.MinimalApplication()
-		app.Spec.Prometheus.Enabled = true
+		app.Spec.Prometheus.Enabled = false
 		err := nais.ApplyDefaults(app)
 		assert.NoError(t, err)
 
-		serviceRoleBinding, err := resourcecreator.ServiceRoleBinding(app)
+		serviceRolePrometheus, err := resourcecreator.ServiceRolePrometheus(app)
 		assert.NoError(t, err)
-		assert.NotNil(t, serviceRoleBinding)
+		assert.Nil(t,serviceRolePrometheus)
 
-		subject := rbac_istio_io_v1alpha1.Subject{
-			User: "cluster.local/ns/istio-system/sa/default",
-		}
+		serviceRoleBindingPrometheus, err := resourcecreator.ServiceRoleBindingPrometheus(app)
+		assert.NoError(t, err)
+		assert.Nil(t, serviceRoleBindingPrometheus)
 
-		assert.Contains(t, serviceRoleBinding.Spec.Subjects, &subject)
 	})
+
+	t.Run("service role and service role binding created, with matching naming. When prometheus is enabled", func(t *testing.T) {
+		app := fixtures.MinimalApplication()
+		app.Spec.Prometheus.Enabled = true
+		app.Spec.AccessPolicy.Ingress.AllowAll = true
+		err := nais.ApplyDefaults(app)
+		assert.NoError(t, err)
+
+
+		serviceRolePrometheus, err := resourcecreator.ServiceRolePrometheus(app)
+		assert.NoError(t, err)
+		assert.NotNil(t,serviceRolePrometheus)
+
+		serviceRoleBindingPrometheus, err := resourcecreator.ServiceRoleBindingPrometheus(app)
+		assert.NoError(t, err)
+		assert.NotNil(t, serviceRoleBindingPrometheus)
+
+		assert.Equal(t,serviceRolePrometheus.ObjectMeta.Name, serviceRoleBindingPrometheus.ObjectMeta.Name)
+	})
+
 }

--- a/pkg/resourcecreator/resourcecreator.go
+++ b/pkg/resourcecreator/resourcecreator.go
@@ -48,6 +48,22 @@ func Create(app *nais.Application, resourceOptions ResourceOptions) ([]runtime.O
 			objects = append(objects, serviceRoleBinding)
 		}
 
+		serviceRolePrometheus, err := ServiceRolePrometheus(app)
+		if err != nil {
+			return nil, fmt.Errorf("while creating access policies: %s", err)
+		}
+		if serviceRolePrometheus != nil {
+			objects = append(objects, serviceRolePrometheus)
+		}
+
+		serviceRoleBindingPrometheus, err := ServiceRoleBindingPrometheus(app)
+		if err != nil {
+			return nil, fmt.Errorf("while creating access policies: %s", err)
+		}
+		if serviceRoleBindingPrometheus != nil {
+			objects = append(objects, serviceRoleBindingPrometheus)
+		}
+
 	} else {
 
 		ingress, err := Ingress(app)


### PR DESCRIPTION
Tok litt tid å komme igang. Og det ble litt flere endringer enn jeg orginalt så for meg. 

Det jeg i bunn og grunn har gjort er å bygge på ServiceRole og ServiceRoleBinding med to nye funksjoner ServiceRolePrometheus og ServiceRoleBindingPrometheus.

Foruten de lange funksjonsnavnene så gjør bare funksjonene små endringer på de allerede genererte structene, så om noe forandres i de underliggende funksjonene skal det gå fint. 

Siste ting, så la jeg også til Paths i AccessRule structet, så det er mulig å kontrollere paths.

Feedback og kritikk er veldig velkommen!