### PR TITLE
Delete ingress object

### DIFF
--- a/naiserator.go
+++ b/naiserator.go
@@ -165,7 +165,6 @@ func (n *Naiserator) createOrUpdateMany(resources []runtime.Object) error {
 }
 
 func (n *Naiserator) removeOrphanIngresses(logger *log.Entry, app *v1alpha1.Application) error {
-
 	if len(app.Spec.Ingresses) == 0 {
 		err := n.ClientSet.ExtensionsV1beta1().Ingresses(app.Namespace).Delete(app.Name, &v1.DeleteOptions{})
 
@@ -173,7 +172,7 @@ func (n *Naiserator) removeOrphanIngresses(logger *log.Entry, app *v1alpha1.Appl
 			return nil
 		}
 
-		logger.Infof("%s: Successfully deleted ingresses", app.Name)
+		logger.Infof("Successfully deleted orphan ingresses for application: %s", app.Name)
 
 		return err
 	}

--- a/naiserator.go
+++ b/naiserator.go
@@ -78,7 +78,7 @@ func (n *Naiserator) synchronize(logger *log.Entry, app *v1alpha1.Application) e
 		return nil
 	}
 
-	if err := n.removeOrphanIngresses(app); err != nil {
+	if err := n.removeOrphanIngresses(logger, app); err != nil {
 		return fmt.Errorf("while removing old resources: %s", err)
 	}
 
@@ -164,16 +164,16 @@ func (n *Naiserator) createOrUpdateMany(resources []runtime.Object) error {
 	return result.ErrorOrNil()
 }
 
-func (n *Naiserator) removeOrphanIngresses(app *v1alpha1.Application, logger *log.Entry) error {
+func (n *Naiserator) removeOrphanIngresses(logger *log.Entry, app *v1alpha1.Application) error {
 
 	if len(app.Spec.Ingresses) == 0 {
-		err := n.ClientSet.ExtensionsV1beta1().Ingresses(app.Namespace).Delete(app.Name,&v1.DeleteOptions{})
+		err := n.ClientSet.ExtensionsV1beta1().Ingresses(app.Namespace).Delete(app.Name, &v1.DeleteOptions{})
 
 		if errors.IsNotFound(err) {
 			return nil
 		}
 
-		logger.Info("%s: Successfully deleted ingresses", app.Name)
+		logger.Infof("%s: Successfully deleted ingresses", app.Name)
 
 		return err
 	}

--- a/naiserator.go
+++ b/naiserator.go
@@ -165,19 +165,19 @@ func (n *Naiserator) createOrUpdateMany(resources []runtime.Object) error {
 }
 
 func (n *Naiserator) removeOrphanIngresses(logger *log.Entry, app *v1alpha1.Application) error {
-	if len(app.Spec.Ingresses) == 0 {
-		err := n.ClientSet.ExtensionsV1beta1().Ingresses(app.Namespace).Delete(app.Name, &v1.DeleteOptions{})
-
-		if errors.IsNotFound(err) {
-			return nil
-		}
-
-		logger.Infof("Successfully deleted orphan ingresses for application: %s", app.Name)
-
-		return err
+	if len(app.Spec.Ingresses) > 0 {
+		return nil
 	}
 
-	return nil
+	err := n.ClientSet.ExtensionsV1beta1().Ingresses(app.Namespace).Delete(app.Name, &v1.DeleteOptions{})
+
+	if errors.IsNotFound(err) {
+		return nil
+	}
+
+	logger.Infof("%s: successfully deleted orphan ingresses", app.Name)
+
+	return err
 }
 
 func (n *Naiserator) Run(stop <-chan struct{}) {


### PR DESCRIPTION
Brukte en del tid på å reprodusere issuen utifra beskrivelsen.
Det som skal til for at issuen blir triggret er at man går fra mer enn 0 Ingresser til 0. Da vil ingressene forbli, før denne forandringen.

Det denne endringen gjør er at den legger til 1 funksjon 'removeOrphanIngresses' som sjekker om det er 0 ingresser i app speccet som blir sendt inn og da prøver den å slette gamle ingresser assosiert med appen.

**Det er alikevel flere viktige ting å merke seg, som vi må gjøre før merge.**
Det er ingen automatiske tester av denne funksjonaliteten, fordi det krever en form for mocking. Dette er noe vi virkelig burde se på.

Den andre tingen, slik jeg har forstått det er at folk som har kommet over fra naisd til naiserator og ikke har spesifisert Ingresses eksplisitt men fortsatt lever på default ingressen vil få problemer. For denne endringen vil fjerne disse ingressene ved syncronize() - når de gjør en endring på app speccet sitt. Dette må vi varsle om i #nais og kanskje også gjøre en undersøkelse av hvem som er påvirket.

Sist men ikke minst, siden det ikke er automatisk testing inkluderer jeg bare måten jeg testet det på;

examples/nais-ingresses.yaml
```yaml
apiVersion: "nais.io/v1alpha1"
kind: "Application"
metadata:
  name: nais-testapp
  namespace: default
  labels:
    team: aura
spec:
  skipCaBundle: true
  image: navikt/nais-testapp:local
  port: 8080
  liveness:
    path: /isalive
  readiness:
    path: /isready
  prometheus:
    path: /metrics
  replicas:
    min: 2
    max: 4
  env:
    - name: MY_CUSTOM_VAR
      value: some_value
  resources:
    limits:
      cpu: 500m
      memory: 512Mi
    requests:
      cpu: 200m
      memory: 256Mi
  ingresses:
    - "https://nais-testapp.nais.preprod.local"
```

```bash
export FILE=examples/nais-ingresses.yaml; 
cat $FILE | kubectl delete -f -; cat $FILE | kubectl apply -f - #lag en app med ingress
kubectl get ingress #verifiser at den eksisterer 
cat $FILE | head -n 30 | kubectl apply -f - #apply uten ingress
kubectl get ingress #verifisert at ingress er vekke 
cat $FILE | kubectl apply -f -; #apply med ingress igjen
kubectl get ingress; #verifiser at den eksisterer igjen
```