### PR TITLE
Use Kubernetes default values for readiness and liveness probes

### DIFF
--- a/pkg/apis/nais.io/v1alpha1/defaults.go
+++ b/pkg/apis/nais.io/v1alpha1/defaults.go
@@ -9,6 +9,9 @@ const (
 	DefaultPortName                 = "http"
 	DefaultServicePort              = 80
 	DefaultAppPort                  = 8080
+	DefaultProbePeriodSeconds       = 10
+	DefaultProbeTimeoutSeconds      = 1
+	DefaultProbeFailureThreshold    = 3
 	DeploymentStrategyRollingUpdate = "RollingUpdate"
 	DeploymentStrategyRecreate      = "Recreate"
 	DefaultVaultMountPath           = "/var/run/secrets/nais.io/vault"
@@ -26,6 +29,11 @@ func getAppDefaults() *Application {
 				Min:                    2,
 				Max:                    4,
 				CpuThresholdPercentage: 50,
+			},
+			Liveness: Probe{
+				PeriodSeconds:    DefaultProbePeriodSeconds,
+				Timeout:          DefaultProbeTimeoutSeconds,
+				FailureThreshold: DefaultProbeFailureThreshold,
 			},
 			Port: DefaultAppPort,
 			Strategy: Strategy{

--- a/pkg/resourcecreator/deployment.go
+++ b/pkg/resourcecreator/deployment.go
@@ -235,12 +235,12 @@ func appContainer(app *nais.Application) corev1.Container {
 		Env:             envVars(app),
 	}
 
-	if app.Spec.Liveness != (nais.Probe{}) {
-		c.LivenessProbe = probe(app.Spec.Liveness)
+	if len(app.Spec.Liveness.Path) > 0 {
+		c.LivenessProbe = probe(app, app.Spec.Liveness)
 	}
 
-	if app.Spec.Readiness != (nais.Probe{}) {
-		c.ReadinessProbe = probe(app.Spec.Readiness)
+	if len(app.Spec.Readiness.Path) > 0 {
+		c.ReadinessProbe = probe(app, app.Spec.Readiness)
 	}
 
 	return c
@@ -377,12 +377,17 @@ func lifeCycle(path string) *corev1.Lifecycle {
 	}
 }
 
-func probe(probe nais.Probe) (k8sprobe *corev1.Probe) {
+func probe(app *nais.Application, probe nais.Probe) (k8sprobe *corev1.Probe) {
+	port := probe.Port
+	if port == 0 {
+		port = app.Spec.Port
+	}
+
 	k8sprobe = &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: probe.Path,
-				Port: intstr.FromString(nais.DefaultPortName),
+				Port: intstr.FromInt(port),
 			},
 		},
 		InitialDelaySeconds: int32(probe.InitialDelay),

--- a/pkg/resourcecreator/deployment_test.go
+++ b/pkg/resourcecreator/deployment_test.go
@@ -177,6 +177,7 @@ func TestDeployment(t *testing.T) {
 
 	t.Run("check if default port is used when liveness port is missing", func(t *testing.T) {
 		app := fixtures.MinimalApplication()
+		app.Spec.Port = 12333
 		app.Spec.Liveness = nais.Probe{
 			Path: "/probe/path",
 		}
@@ -190,7 +191,8 @@ func TestDeployment(t *testing.T) {
 		appContainer := resourcecreator.GetContainerByName(deploy.Spec.Template.Spec.Containers, app.Name)
 		assert.NotNil(t, appContainer)
 
-		assert.Equal(t, nais.DefaultPortName, appContainer.LivenessProbe.HTTPGet.Port.StrVal)
+		assert.Equal(t, app.Spec.Port, appContainer.LivenessProbe.HTTPGet.Port.IntValue())
+		assert.Nil(t, appContainer.ReadinessProbe)
 	})
 
 	t.Run("liveness configuration is set up correctly", func(t *testing.T) {


### PR DESCRIPTION
Fixes #64

Checking against an empty `Probe` object does not work anymore. The real definition of a defined probe is that the `path` is set.