### PR TITLE
Added counter to application events with same message

### DIFF
--- a/naiserator.go
+++ b/naiserator.go
@@ -165,7 +165,7 @@ func (n *Naiserator) synchronize(logger *log.Entry, app *v1alpha1.Application) e
 		return fmt.Errorf("while storing application sync metadata: %s", err)
 	}
 
-	_, err = n.reportEvent(app.CreateEvent("synchronize", fmt.Sprintf("successfully synchronized application resources (hash = %s)", hash), "Normal"))
+	_, err = n.reportEvent(app.CreateEvent("synchronize", "successfully synchronized application resources", "Normal"))
 	if err != nil {
 		logger.Errorf("While creating an event for this error, another error occurred: %s", err)
 	}

--- a/naiserator.go
+++ b/naiserator.go
@@ -63,15 +63,29 @@ func NewNaiserator(clientSet kubernetes.Interface, appClient *clientV1Alpha1.Cli
 }
 
 // Creates a Kubernetes event.
-func (n *Naiserator) reportEvent(event *corev1.Event) (*corev1.Event, error) {
-	return n.ClientSet.CoreV1().Events(event.Namespace).Create(event)
+func (n *Naiserator) reportEvent(reportedEvent *corev1.Event) (*corev1.Event, error) {
+	events, err := n.ClientSet.CoreV1().Events(reportedEvent.Namespace).List(v1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.uid=%s", reportedEvent.InvolvedObject.Name, reportedEvent.InvolvedObject.UID),
+	})
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("while getting events for app %s, got error: %s", reportedEvent.InvolvedObject.Name, err)
+	}
+
+	for _, event := range events.Items {
+		if event.Message == reportedEvent.Message {
+			event.Count++
+			event.LastTimestamp = reportedEvent.LastTimestamp
+			return n.ClientSet.CoreV1().Events(event.Namespace).Update(&event)
+		}
+	}
+
+	return n.ClientSet.CoreV1().Events(reportedEvent.Namespace).Create(reportedEvent)
 }
 
 // Reports an error through the error log, a Kubernetes event, and possibly logs a failure in event creation.
 func (n *Naiserator) reportError(source string, err error, app *v1alpha1.Application) {
 	log.Error(err)
-	ev := app.CreateEvent(source, err.Error(), "Warning")
-	_, err = n.reportEvent(ev)
+	_, err = n.reportEvent(app.CreateEvent(source, err.Error(), "Warning"))
 	if err != nil {
 		log.Errorf("While creating an event for this error, another error occurred: %s", err)
 	}

--- a/pkg/apis/nais.io/v1alpha1/application_event.go
+++ b/pkg/apis/nais.io/v1alpha1/application_event.go
@@ -27,5 +27,6 @@ func (in *Application) CreateEvent(reason, message, typeStr string) *corev1.Even
 		FirstTimestamp:      metav1.Time{Time: time.Now()},
 		LastTimestamp:       metav1.Time{Time: time.Now()},
 		Type:                typeStr,
+		Count:               1,
 	}
 }


### PR DESCRIPTION
Fixes the repetition of events, seen in #100

It reduces the spam by associating a counter with events that report the
same message. It works for all kinds of events so everything from
repeating errors to Successful sync messages will be grouped together
and associated with a counter and a timespan in which all the errors
appeared.

What I've done:

I've expanded the reportEvent function to first get all the events for
the current app. Then match based on message and if it finds a matching
message it increments that events counter and updates its lastSeen
timestamp. Then it updates the event.

If it can't find the same event it creates a new one.

Since the feature is implemented in reportEvent it works for all kinds
of events not just Warnings/Errors

I've also made the decision to not to create a new event if the current
events for the app can't be fetched. This is to stop the creation of two
events with the same message and different counters.