### PR TITLE
Refactor main loop

### DIFF
--- a/cmd/naiserator/main.go
+++ b/cmd/naiserator/main.go
@@ -44,6 +44,7 @@ func run() error {
 		TimestampFormat: time.RFC3339Nano,
 	}
 	log.SetFormatter(&formatter)
+	log.SetLevel(log.DebugLevel)
 
 	log.Info("Naiserator starting up")
 
@@ -108,6 +109,7 @@ func run() error {
 		cfg.Kafka.Enabled)
 
 	applicationInformerFactory.Start(stopCh)
+	go n.Main()
 	n.Run(stopCh)
 	<-stopCh
 

--- a/hack/generator/updater.go.tpl
+++ b/hack/generator/updater.go.tpl
@@ -54,7 +54,7 @@ func {{.Name}}(client {{.Interface}}, old, new {{.Type}}) func() error {
 
 {{end}}
 
-func CreateOrUpdate(clientSet kubernetes.Interface, customClient *clientV1Alpha1.Clientset, resource runtime.Object) func() error {
+func CreateOrUpdate(clientSet kubernetes.Interface, customClient clientV1Alpha1.Interface, resource runtime.Object) func() error {
 	switch new := resource.(type) {
 	{{range .}}
 		case {{.Type}}:
@@ -73,7 +73,7 @@ func CreateOrUpdate(clientSet kubernetes.Interface, customClient *clientV1Alpha1
 	}
 }
 
-func CreateOrRecreate(clientSet kubernetes.Interface, customClient *clientV1Alpha1.Clientset, resource runtime.Object) func() error {
+func CreateOrRecreate(clientSet kubernetes.Interface, customClient clientV1Alpha1.Interface, resource runtime.Object) func() error {
 	switch new := resource.(type) {
 	{{range .}}
 		case {{.Type}}:
@@ -94,7 +94,7 @@ func CreateOrRecreate(clientSet kubernetes.Interface, customClient *clientV1Alph
 	}
 }
 
-func DeleteIfExists(clientSet kubernetes.Interface, customClient *clientV1Alpha1.Clientset, resource runtime.Object) func() error {
+func DeleteIfExists(clientSet kubernetes.Interface, customClient clientV1Alpha1.Interface, resource runtime.Object) func() error {
 	switch new := resource.(type) {
 	{{range .}}
 		case {{.Type}}:

--- a/pkg/apis/nais.io/v1alpha1/application_types.go
+++ b/pkg/apis/nais.io/v1alpha1/application_types.go
@@ -9,6 +9,7 @@ import (
 	hash "github.com/mitchellh/hashstructure"
 	"github.com/nais/naiserator/pkg/event"
 	"github.com/nais/naiserator/pkg/naiserator/config"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -265,6 +266,16 @@ func (in Application) Hash() (string, error) {
 
 	h, err := hash.Hash(relevantValues, nil)
 	return strconv.FormatUint(h, 10), err
+}
+
+func (in *Application) LogFields() log.Fields {
+	return log.Fields{
+		"namespace":       in.GetNamespace(),
+		"apiversion":      in.APIVersion,
+		"resourceversion": in.GetResourceVersion(),
+		"application":     in.GetName(),
+		"correlation-id":  in.Status.CorrelationID,
+	}
 }
 
 func (in Application) Cluster() string {

--- a/pkg/apis/nais.io/v1alpha1/application_types.go
+++ b/pkg/apis/nais.io/v1alpha1/application_types.go
@@ -271,7 +271,6 @@ func (in Application) Hash() (string, error) {
 func (in *Application) LogFields() log.Fields {
 	return log.Fields{
 		"namespace":       in.GetNamespace(),
-		"apiversion":      in.APIVersion,
 		"resourceversion": in.GetResourceVersion(),
 		"application":     in.GetName(),
 		"correlation-id":  in.Status.CorrelationID,

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -1,0 +1,84 @@
+// Package informer keeps up with changes in Kubernetes and reports back when an application is changed.
+package informer
+
+import (
+	"fmt"
+
+	nais "github.com/nais/naiserator/pkg/apis/nais.io/v1alpha1"
+	nais_informers "github.com/nais/naiserator/pkg/client/informers/externalversions"
+	nais_informers_typed "github.com/nais/naiserator/pkg/client/informers/externalversions/nais.io/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/cache"
+)
+
+type Synchronizer interface {
+	Enqueue(*nais.Application)
+}
+
+type Informer struct {
+	stopChannel     chan struct{}
+	informer        nais_informers_typed.ApplicationInformer
+	synchronizer    Synchronizer
+	informerFactory nais_informers.SharedInformerFactory
+}
+
+func New(synchronizer Synchronizer, sharedInformerFactory nais_informers.SharedInformerFactory) *Informer {
+	i := &Informer{
+		synchronizer:    synchronizer,
+		informerFactory: sharedInformerFactory,
+		stopChannel:     make(chan struct{}, 1),
+	}
+
+	sharedInformerFactory.Naiserator().V1alpha1().Applications().Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(newPod interface{}) {
+				i.watchCallback(newPod)
+			},
+			UpdateFunc: func(oldPod, newPod interface{}) {
+				i.watchCallback(newPod)
+			},
+		},
+	)
+
+	return i
+}
+
+// This function is passed to the Application resource watcher.
+// It will be called once for every application resource, which
+// must be type cast from interface{} to Application.
+func (informer *Informer) watchCallback(unstructured interface{}) {
+	var app *nais.Application
+	var ok bool
+
+	if unstructured == nil {
+		return
+	}
+
+	app, ok = unstructured.(*nais.Application)
+	if !ok {
+		// type cast failed; discard
+		log.Errorf("watchCallback encountered invalid Application resource of type %T", unstructured)
+		return
+	}
+
+	informer.synchronizer.Enqueue(app)
+}
+
+func (informer *Informer) Stop() {
+	informer.stopChannel <- struct{}{}
+}
+
+func (informer *Informer) Run() error {
+	log.Info("Starting application informer")
+
+	informer.informerFactory.Start(informer.stopChannel)
+
+	i := informer.informerFactory.Naiserator().V1alpha1().Applications().Informer()
+	if !cache.WaitForCacheSync(informer.stopChannel, i.HasSynced) {
+		return fmt.Errorf("timed out waiting for cache sync")
+	}
+
+	log.Infof("Cache has been populated")
+
+	return nil
+}

--- a/pkg/synchronizer/rollout.go
+++ b/pkg/synchronizer/rollout.go
@@ -8,7 +8,7 @@ import (
 
 // Rollout represents the data neccessary to rollout an application to Kubernetes.
 type Rollout struct {
-	App                nais.Application
+	App                *nais.Application
 	ResourceOptions    resourcecreator.ResourceOptions
 	ResourceOperations resourcecreator.ResourceOperations
 }

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -237,6 +237,8 @@ func (n *Synchronizer) ClusterOperations(rollout Rollout) []func() error {
 			fn = updater.CreateOrRecreate(n.ClientSet, n.AppClient, rop.Resource)
 		case resourcecreator.OperationDeleteIfExists:
 			fn = updater.DeleteIfExists(n.ClientSet, n.AppClient, rop.Resource)
+		default:
+			log.Fatalf("BUG: no such operation %d", rop.Operation)
 		}
 
 		funcs = append(funcs, fn)

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -32,11 +32,11 @@ type Synchronizer struct {
 	workQueue       chan v1alpha1.Application
 	ClientSet       kubernetes.Interface
 	KafkaEnabled    bool
-	AppClient       *clientV1Alpha1.Clientset
+	AppClient       clientV1Alpha1.Interface
 	ResourceOptions resourcecreator.ResourceOptions
 }
 
-func New(clientSet kubernetes.Interface, appClient *clientV1Alpha1.Clientset, resourceOptions resourcecreator.ResourceOptions, kafkaEnabled bool) *Synchronizer {
+func New(clientSet kubernetes.Interface, appClient clientV1Alpha1.Interface, resourceOptions resourcecreator.ResourceOptions, kafkaEnabled bool) *Synchronizer {
 	naiserator := Synchronizer{
 		workQueue:       make(chan v1alpha1.Application, 1024),
 		ClientSet:       clientSet,

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -145,7 +145,6 @@ func (n *Synchronizer) Main() {
 func (n *Synchronizer) UpdateStatus(app v1alpha1.Application, rollout Rollout) error {
 	app.SetCorrelationID(rollout.App.Status.CorrelationID)
 	app.SetLastSyncedHash(rollout.App.LastSyncedHash())
-	// app.NilFix()  // FIXME unneeded?????
 
 	_, err := n.AppClient.NaiseratorV1alpha1().Applications(app.Namespace).Update(&app)
 	if err != nil {

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -1,1 +1,93 @@
 package synchronizer_test
+
+import (
+	"testing"
+
+	"github.com/nais/naiserator/pkg/apis/nais.io/v1alpha1"
+	nais_fake "github.com/nais/naiserator/pkg/client/clientset/versioned/fake"
+	"github.com/nais/naiserator/pkg/resourcecreator"
+	"github.com/nais/naiserator/pkg/synchronizer"
+	"github.com/nais/naiserator/pkg/test/fixtures"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Test an entire synchronization run, i.e. create numerous resources
+// from an Application resource.
+func TestSynchronizer(t *testing.T) {
+	// Create Application fixture
+	app := fixtures.MinimalApplication()
+	name := app.GetName()
+	namespace := app.GetNamespace()
+
+	// Test that a resource has been created in the fake cluster
+	testResource := func(resource metav1.Object, err error) {
+		assert.NoError(t, err)
+		assert.NotNil(t, resource)
+		assert.Equal(t, name, resource.GetName())
+		assert.Equal(t, namespace, resource.GetNamespace())
+	}
+
+	// Test that a resource does not exist in the fake cluster
+	testResourceNotExist := func(resource metav1.Object, err error) {
+		assert.True(t, errors.IsNotFound(err), "the resource found in the cluster should not be there")
+		assert.Nil(t, resource)
+	}
+
+	// Initialize synchronizer with fake Kubernetes clients
+	clientSet := fake.NewSimpleClientset()
+	appClient := nais_fake.NewSimpleClientset()
+	resourceOptions := resourcecreator.NewResourceOptions()
+	kafkaEnabled := false
+
+	syncer := synchronizer.New(
+		clientSet,
+		appClient,
+		resourceOptions,
+		kafkaEnabled,
+	)
+
+	// Store the Application resource in the cluster before testing commences.
+	// This simulates a deployment into the cluster which is then picked up by the
+	// informer queue.
+	app, err := appClient.Naiserator().Applications(namespace).Create(app)
+	if err != nil {
+		t.Fatalf("Application resource cannot be persisted to fake Kubernetes: %s", err)
+	}
+
+	// Create an Ingress object that should be deleted once processing has run.
+	app.Spec.Ingresses = []string{"https://foo.bar"}
+	ingress, err := resourcecreator.Ingress(app)
+	app.Spec.Ingresses = []string{}
+	ingress, err = clientSet.ExtensionsV1beta1().Ingresses(namespace).Create(ingress)
+	if err != nil || len(ingress.Spec.Rules) == 0 {
+		t.Fatalf("BUG: error creating ingress for testing: %s", err)
+	}
+
+	// Create a hash from the persisted resource, having applied the default values
+	hashAppCopy := app.DeepCopy()
+	assert.NoError(t, v1alpha1.ApplyDefaults(hashAppCopy))
+	hash, err := hashAppCopy.Hash()
+	assert.NoError(t, err)
+
+	// Run synchronization processing.
+	// This will attempt to store numerous resources in Kubernetes.
+	syncer.Process(*app)
+
+	// Test that the Application was updated successfully after processing,
+	// and that the hash is present.
+	persistedApp, err := appClient.Naiserator().Applications(namespace).Get(name, metav1.GetOptions{})
+	assert.NotNil(t, persistedApp)
+	assert.NoError(t, err)
+	assert.Equalf(t, hash, persistedApp.LastSyncedHash(), "Application resource hash in Kubernetes doesn't match local version")
+
+	// Test that a base resource set was created successfully
+	testResource(clientSet.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{}))
+	testResource(clientSet.CoreV1().Services(namespace).Get(name, metav1.GetOptions{}))
+	testResource(clientSet.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{}))
+
+	// Test that the Ingress resource was removed
+	testResourceNotExist(clientSet.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{}))
+}

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -3,7 +3,6 @@ package synchronizer_test
 import (
 	"testing"
 
-	"github.com/nais/naiserator/pkg/apis/nais.io/v1alpha1"
 	nais_fake "github.com/nais/naiserator/pkg/client/clientset/versioned/fake"
 	"github.com/nais/naiserator/pkg/resourcecreator"
 	"github.com/nais/naiserator/pkg/synchronizer"
@@ -66,12 +65,6 @@ func TestSynchronizer(t *testing.T) {
 		t.Fatalf("BUG: error creating ingress for testing: %s", err)
 	}
 
-	// Create a hash from the persisted resource, having applied the default values
-	hashAppCopy := app.DeepCopy()
-	assert.NoError(t, v1alpha1.ApplyDefaults(hashAppCopy))
-	hash, err := hashAppCopy.Hash()
-	assert.NoError(t, err)
-
 	// Run synchronization processing.
 	// This will attempt to store numerous resources in Kubernetes.
 	syncer.Process(app)
@@ -81,7 +74,7 @@ func TestSynchronizer(t *testing.T) {
 	persistedApp, err := appClient.Naiserator().Applications(namespace).Get(name, metav1.GetOptions{})
 	assert.NotNil(t, persistedApp)
 	assert.NoError(t, err)
-	assert.Equalf(t, hash, persistedApp.LastSyncedHash(), "Application resource hash in Kubernetes doesn't match local version")
+	assert.Equalf(t, app.LastSyncedHash(), persistedApp.LastSyncedHash(), "Application resource hash in Kubernetes doesn't match local version")
 
 	// Test that a base resource set was created successfully
 	testResource(clientSet.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{}))

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -74,7 +74,7 @@ func TestSynchronizer(t *testing.T) {
 
 	// Run synchronization processing.
 	// This will attempt to store numerous resources in Kubernetes.
-	syncer.Process(*app)
+	syncer.Process(app)
 
 	// Test that the Application was updated successfully after processing,
 	// and that the hash is present.

--- a/updater/zz_generated.go
+++ b/updater/zz_generated.go
@@ -236,7 +236,7 @@ func RoleBinding(client typed_rbac_v1.RoleBindingInterface, old, new *rbacv1.Rol
 	}
 }
 
-func CreateOrUpdate(clientSet kubernetes.Interface, customClient *clientV1Alpha1.Clientset, resource runtime.Object) func() error {
+func CreateOrUpdate(clientSet kubernetes.Interface, customClient clientV1Alpha1.Interface, resource runtime.Object) func() error {
 	switch new := resource.(type) {
 
 	case *corev1.Service:
@@ -376,7 +376,7 @@ func CreateOrUpdate(clientSet kubernetes.Interface, customClient *clientV1Alpha1
 	}
 }
 
-func CreateOrRecreate(clientSet kubernetes.Interface, customClient *clientV1Alpha1.Clientset, resource runtime.Object) func() error {
+func CreateOrRecreate(clientSet kubernetes.Interface, customClient clientV1Alpha1.Interface, resource runtime.Object) func() error {
 	switch new := resource.(type) {
 
 	case *corev1.Service:
@@ -540,7 +540,7 @@ func CreateOrRecreate(clientSet kubernetes.Interface, customClient *clientV1Alph
 	}
 }
 
-func DeleteIfExists(clientSet kubernetes.Interface, customClient *clientV1Alpha1.Clientset, resource runtime.Object) func() error {
+func DeleteIfExists(clientSet kubernetes.Interface, customClient clientV1Alpha1.Interface, resource runtime.Object) func() error {
 	switch new := resource.(type) {
 
 	case *corev1.Service:


### PR DESCRIPTION
This PR splits the Naiserator class into an informer component and a synchronization component with a work queue. This results in _single responsibility_ for both classes. Object references have been replaced with interfaces to improve testability.

The informer subscribes to Application updates and feeds the work queue through an `Enqueue(app)` function.

The synchronizer works through the application queue, generates resources, and persists them in the cluster.

Fixes #114 .