### PR TITLE
Outbound.rules is not required

### DIFF
--- a/config/nais.io_applications.yaml
+++ b/config/nais.io_applications.yaml
@@ -452,9 +452,6 @@ spec:
                         - application
                         type: object
                       type: array
-                  required:
-                  - external
-                  - rules
                   type: object
               type: object
             configMaps:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/tools v0.0.0-20191015211201-9c6d90b5a7d0 // indirect
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190408172450-b1350b9e3bc2 // kubernetes-1.12.7

--- a/pkg/apis/nais.io/v1alpha1/application_types.go
+++ b/pkg/apis/nais.io/v1alpha1/application_types.go
@@ -177,8 +177,8 @@ type AccessPolicyInbound struct {
 }
 
 type AccessPolicyOutbound struct {
-	Rules    []AccessPolicyRule         `json:"rules"`
-	External []AccessPolicyExternalRule `json:"external"`
+	Rules    []AccessPolicyRule         `json:"rules,omitempty"`
+	External []AccessPolicyExternalRule `json:"external,omitempty"`
 }
 
 type AccessPolicy struct {


### PR DESCRIPTION
Neither `spec.accessPolicy.outbound.rules` nor `spec.accessPolicy.outbound.external` is required.