### PR TITLE
Support multiple formats for vault secret mounting

### DIFF
--- a/config/nais.io_applications.yaml
+++ b/config/nais.io_applications.yaml
@@ -289,6 +289,15 @@ spec:
                 paths:
                   items:
                     properties:
+                      format:
+                        enum:
+                        - flatten
+                        - json
+                        - yaml
+                        - env
+                        - properties
+                        - ""
+                        type: string
                       kvPath:
                         type: string
                       mountPath:

--- a/pkg/apis/nais.io/v1alpha1/application_types.go
+++ b/pkg/apis/nais.io/v1alpha1/application_types.go
@@ -142,6 +142,8 @@ type EnvVar struct {
 type SecretPath struct {
 	MountPath string `json:"mountPath"`
 	KvPath    string `json:"kvPath"`
+	// +kubebuilder:validation:Enum=flatten;json;yaml;env;properties;""
+	Format    string `json:"format,omitempty"`
 }
 
 type Vault struct {

--- a/pkg/vault/fixtures/user_secrets.json.golden
+++ b/pkg/vault/fixtures/user_secrets.json.golden
@@ -18,6 +18,7 @@
         "-vault=https://vault.adeo.no",
         "-save-token=/var/run/secrets/nais.io/vault/vault_token",
         "-cn=secret:/serviceuser/data/test/srvfasit:dir=/secrets/credential/srvfasit,fmt=flatten,retries=1",
+        "-cn=secret:/oracle/data/dev/testdb:file=/secrets/oracle/testdb.json,fmt=json,retries=1",
         "-cn=secret:/certificate/data/dev/fasit-keystore:dir=/secrets/certificate/fasit-keystore,fmt=flatten,retries=1"
       ],
       "env": [
@@ -43,6 +44,11 @@
         },
         {
           "name": "vault-volume",
+          "mountPath": "/secrets/oracle/testdb.json",
+          "subPath": "vault/secrets/oracle/testdb.json"
+        },
+        {
+          "name": "vault-volume",
           "mountPath": "/secrets/certificate/fasit-keystore",
           "subPath": "vault/secrets/certificate/fasit-keystore"
         },
@@ -64,6 +70,11 @@
           "name": "vault-volume",
           "mountPath": "/secrets/credential/srvfasit",
           "subPath": "vault/secrets/credential/srvfasit"
+        },
+        {
+          "name": "vault-volume",
+          "mountPath": "/secrets/oracle/testdb.json",
+          "subPath": "vault/secrets/oracle/testdb.json"
         },
         {
           "name": "vault-volume",

--- a/pkg/vault/vaultcontainer.go
+++ b/pkg/vault/vaultcontainer.go
@@ -142,7 +142,21 @@ func (c config) createInitContainer(paths []nais.SecretPath) k8score.Container {
 	}
 
 	for _, path := range paths {
-		args = append(args, fmt.Sprintf("-cn=secret:%s:dir=%s,fmt=flatten,retries=1", path.KvPath, path.MountPath))
+		var format string
+		if len(path.Format) > 0 {
+			format = path.Format
+		} else {
+			format = "flatten"
+		}
+
+		var paramname string
+		if format == "flatten" {
+			paramname = "dir"
+		} else {
+			paramname = "file"
+		}
+
+		args = append(args, fmt.Sprintf("-cn=secret:%s:%s=%s,fmt=%s,retries=1", path.KvPath, paramname, path.MountPath, format))
 	}
 
 	return k8score.Container{

--- a/pkg/vault/vaultcontainer_test.go
+++ b/pkg/vault/vaultcontainer_test.go
@@ -57,6 +57,11 @@ func TestVaultContainerCreation(t *testing.T) {
 					MountPath: "/secrets/credential/srvfasit",
 				},
 				{
+					KvPath:    "/oracle/data/dev/testdb",
+					MountPath: "/secrets/oracle/testdb.json",
+					Format: "json",
+				},
+				{
 					KvPath:    "/certificate/data/dev/fasit-keystore",
 					MountPath: "/secrets/certificate/fasit-keystore",
 				},


### PR DESCRIPTION
Lar oss injecte secrets som json, yaml, env eller properties.

Endringen er bakoverkompatibel; hvis "format"-feltet ikke er satt, så er "flatten" default.

Jeg tenker å dark-launche denne featuren, ved å la være å dokumentere at den finnes - så tester vi på noen apper, og hvis det funker som forventet, så forteller vi til utviklerne at den finnes.