### PR TITLE
Do not update service account

### DIFF
--- a/pkg/resourcecreator/resourcecreator.go
+++ b/pkg/resourcecreator/resourcecreator.go
@@ -24,7 +24,7 @@ func Create(app *nais.Application, resourceOptions ResourceOptions) (ResourceOpe
 
 	ops := ResourceOperations{
 		{Service(app), OperationCreateOrUpdate},
-		{ServiceAccount(app, resourceOptions), OperationCreateOrUpdate},
+		{ServiceAccount(app, resourceOptions), OperationCreateIfNotExists},
 		{HorizontalPodAutoscaler(app), OperationCreateOrUpdate},
 	}
 

--- a/pkg/resourcecreator/resourcecreator_test.go
+++ b/pkg/resourcecreator/resourcecreator_test.go
@@ -137,9 +137,12 @@ func TestCreate(t *testing.T) {
 		objects := getRealObjects(resources.Extract(resourcecreator.OperationCreateOrUpdate))
 		assert.NotNil(t, objects.hpa)
 		assert.NotNil(t, objects.service)
-		assert.NotNil(t, objects.serviceAccount)
 		assert.NotNil(t, objects.deployment)
 		assert.Nil(t, objects.ingress)
+
+		// Test that the ServiceAccount is created
+		objects = getRealObjects(resources.Extract(resourcecreator.OperationCreateIfNotExists))
+		assert.NotNil(t, objects.serviceAccount)
 
 		// Test that the Ingress is deleted
 		objects = getRealObjects(resources.Extract(resourcecreator.OperationDeleteIfExists))

--- a/pkg/resourcecreator/resourcecreator_test.go
+++ b/pkg/resourcecreator/resourcecreator_test.go
@@ -140,10 +140,6 @@ func TestCreate(t *testing.T) {
 		assert.NotNil(t, objects.deployment)
 		assert.Nil(t, objects.ingress)
 
-		// Test that the ServiceAccount is created
-		objects = getRealObjects(resources.Extract(resourcecreator.OperationCreateIfNotExists))
-		assert.NotNil(t, objects.serviceAccount)
-
 		// Test that the Ingress is deleted
 		objects = getRealObjects(resources.Extract(resourcecreator.OperationDeleteIfExists))
 		assert.NotNil(t, objects.ingress)

--- a/pkg/resourcecreator/testdata/vanilla_gcp.json
+++ b/pkg/resourcecreator/testdata/vanilla_gcp.json
@@ -101,7 +101,7 @@
       }
     },
     {
-      "operation": "CreateOrUpdate",
+      "operation": "CreateIfNotExists",
       "resource": {
         "apiVersion": "v1",
         "kind": "ServiceAccount",

--- a/pkg/resourcecreator/testdata/vanilla_on_premises.json
+++ b/pkg/resourcecreator/testdata/vanilla_on_premises.json
@@ -60,7 +60,7 @@
       }
     },
     {
-      "operation": "CreateOrUpdate",
+      "operation": "CreateIfNotExists",
       "resource": {
         "apiVersion": "v1",
         "kind": "ServiceAccount",


### PR DESCRIPTION
Updating the service account overwrites the list of secrets, and
triggers creation of new SA tokens

https://github.com/kubernetes/kubernetes/issues/84642