### PR TITLE
add explicit mapping of domain suffixes and istio gateways

### DIFF
--- a/cmd/naiserator/main.go
+++ b/cmd/naiserator/main.go
@@ -106,6 +106,11 @@ func run() error {
 	resourceOptions.JwkerEnabled = cfg.Features.Jwker
 	resourceOptions.AzureratorEnabled = cfg.Features.Azurerator
 	resourceOptions.HostAliases = cfg.HostAliases
+	resourceOptions.GatewayMappings = cfg.GatewayMappings
+
+	if len(resourceOptions.GoogleProjectId) > 0 && len(resourceOptions.GatewayMappings) == 0 {
+		return fmt.Errorf("running in GCP and no gateway mappings defined. Will not be able to set the right gateway on the Virtual Service based on the provided ingresses")
+	}
 
 	applicationInformerFactory := createApplicationInformerFactory(kubeconfig, cfg.Informer.FullSyncInterval)
 	applicationClientset := createApplicationClientset(kubeconfig)

--- a/pkg/apis/nais.io/v1/jwker_types.go
+++ b/pkg/apis/nais.io/v1/jwker_types.go
@@ -7,7 +7,7 @@ import (
 
 type JwkerSpec struct {
 	AccessPolicy *v1alpha1.AccessPolicy `json:"accessPolicy"`
-	SecretName   string        `json:"secretName"`
+	SecretName   string                 `json:"secretName"`
 }
 
 // JwkerStatus defines the observed state of Jwker

--- a/pkg/naiserator/config/config.go
+++ b/pkg/naiserator/config/config.go
@@ -53,26 +53,32 @@ type Vault struct {
 	KeyValuePath       string `json:"kv-path"`
 }
 
+type GatewayMapping struct {
+	DomainSuffix string `json:"domainSuffix"`
+	GatewayName  string `json:"gatewayName"`
+}
+
 type HostAlias struct {
 	Host    string `json:"host"`
 	Address string `json:"address"`
 }
 
 type Config struct {
-	Bind                              string        `json:"bind"`
-	Informer                          Informer      `json:"informer"`
-	Synchronizer                      Synchronizer  `json:"synchronizer"`
-	Kubeconfig                        string       `json:"kubeconfig"`
-	ClusterName                       string       `json:"cluster-name"`
-	GoogleProjectId                   string       `json:"google-project-id"`
-	GoogleCloudSQLProxyContainerImage string       `json:"google-cloud-sql-proxy-container-image"`
-	Log                               Log          `json:"log"`
-	Features                          Features     `json:"features"`
-	Securelogs                        Securelogs   `json:"securelogs"`
-	Proxy                             Proxy        `json:"proxy"`
-	Vault                             Vault        `json:"vault"`
-	Kafka                             kafka.Config `json:"kafka"`
-	HostAliases                       []HostAlias  `json:"host-aliases"`
+	Bind                              string           `json:"bind"`
+	Informer                          Informer         `json:"informer"`
+	Synchronizer                      Synchronizer     `json:"synchronizer"`
+	Kubeconfig                        string           `json:"kubeconfig"`
+	ClusterName                       string           `json:"cluster-name"`
+	GoogleProjectId                   string           `json:"google-project-id"`
+	GoogleCloudSQLProxyContainerImage string           `json:"google-cloud-sql-proxy-container-image"`
+	Log                               Log              `json:"log"`
+	Features                          Features         `json:"features"`
+	Securelogs                        Securelogs       `json:"securelogs"`
+	Proxy                             Proxy            `json:"proxy"`
+	Vault                             Vault            `json:"vault"`
+	Kafka                             kafka.Config     `json:"kafka"`
+	HostAliases                       []HostAlias      `json:"host-aliases"`
+	GatewayMappings                   []GatewayMapping `json:"gateway-mappings"`
 }
 
 const (

--- a/pkg/resourcecreator/const.go
+++ b/pkg/resourcecreator/const.go
@@ -16,8 +16,7 @@ const (
 	IstioNamespace                          = "istio-system"                         // Which namespace Istio is installed in
 	IstioServiceEntryLocationExternal       = "MESH_EXTERNAL"                        // Service entries external to the cluster
 	IstioServiceEntryResolutionDNS          = "DNS"                                  // Service entry lookup type
-	IstioGatewayPrefix                      = "istio-system/ingress-gateway-%s"
-	IstioVirtualServiceTotalWeight    int32 = 100 // The total weight of all routes must equal 100
+	IstioVirtualServiceTotalWeight    int32 = 100                                    // The total weight of all routes must equal 100
 	GoogleIAMAPIVersion                     = "iam.cnrm.cloud.google.com/v1beta1"
 	GoogleIAMServiceAccountNamespace        = "serviceaccounts"
 	GoogleStorageAPIVersion                 = "storage.cnrm.cloud.google.com/v1beta1"

--- a/pkg/resourcecreator/resourcecreator.go
+++ b/pkg/resourcecreator/resourcecreator.go
@@ -119,7 +119,7 @@ func Create(app *nais.Application, resourceOptions ResourceOptions) (ResourceOpe
 
 	if resourceOptions.AccessPolicy {
 		ops = append(ops, ResourceOperation{NetworkPolicy(app, resourceOptions), OperationCreateOrUpdate})
-		vses, err := VirtualServices(app)
+		vses, err := VirtualServices(app, resourceOptions.GatewayMappings)
 
 		if err != nil {
 			return nil, fmt.Errorf("unable to create VirtualServices: %s", err)

--- a/pkg/resourcecreator/resourceoptions.go
+++ b/pkg/resourcecreator/resourceoptions.go
@@ -18,6 +18,7 @@ type ResourceOptions struct {
 	AzureratorEnabled           bool
 	AzureratorSecretName        string
 	HostAliases                 []config.HostAlias
+	GatewayMappings             []config.GatewayMapping
 }
 
 // NewResourceOptions creates a struct with the default resource options.

--- a/pkg/vault/vaultcontainer_test.go
+++ b/pkg/vault/vaultcontainer_test.go
@@ -1,10 +1,10 @@
 package vault_test
 
 import (
-	"testing"
-	"github.com/spf13/viper"
 	"github.com/nais/naiserator/pkg/vault"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestFeatureFlagging(t *testing.T) {


### PR DESCRIPTION
PR changes istio gateway resolving mechanism. Today this currently takes the provided ingress, splits the domain and resolves the gateway name based on a naming scheme. 
Instead, this PR makes this resolving explicit as provided configuration where one maps the domain suffix with a fully qualified gateway name.

Example with naiserator.yaml
```
gateway-mappings:
  - domainSuffix: .dev-gcp.nais.io
     gatewayName: istio-system/ingress-gateway-nais-io
  ... 
```

Note: Needs update of nais-yaml with mappings before merge