### PR TITLE
chore: remove unused constant (value is changed in jwker)

### DIFF
--- a/pkg/apis/nais.io/v1alpha1/application_types.go
+++ b/pkg/apis/nais.io/v1alpha1/application_types.go
@@ -22,7 +22,6 @@ const (
 	DefaultSecretMountPath            = "/var/run/secrets"
 	DefaultJwkerMountPath             = "/var/run/secrets/nais.io/jwker"
 	DefaultAzureratorMountPath        = "/var/run/secrets/nais.io/azure"
-	JwkerCredentialsFilename          = "jwks" // from jwker/pkg/secret/secrets.go: JwksSecretKey
 )
 
 func GetDefaultMountPath(name string) string {


### PR DESCRIPTION
const `JwkerCredentialsFilename` is potentially changed in https://github.com/nais/jwker/pull/2
* the constant seems not to be used in naiserator at all