### PR TITLE
user-configurable Azure AD tenant target

### DIFF
--- a/config/crd/nais.io_applications.yaml
+++ b/config/crd/nais.io_applications.yaml
@@ -127,6 +127,11 @@ spec:
                       items:
                         type: string
                       type: array
+                    tenant:
+                      enum:
+                      - nav.no
+                      - trygdeetaten.no
+                      type: string
                   required:
                   - enabled
                   type: object

--- a/pkg/apis/nais.io/v1/azureadapplication_types.go
+++ b/pkg/apis/nais.io/v1/azureadapplication_types.go
@@ -41,6 +41,9 @@ type AzureAdApplicationSpec struct {
 	LogoutUrl string `json:"logoutUrl,omitempty"`
 	// SecretName is the name of the resulting Secret resource to be created
 	SecretName string `json:"secretName"`
+	// Tenant is an optional alias for targeting a tenant that an instance of Azurerator that processes resources for said tenant.
+	// Can be omitted if only running a single instance or targeting the default tenant.
+	Tenant string `json:"tenant,omitempty"`
 }
 
 // AzureAdApplicationStatus defines the observed state of AzureAdApplication

--- a/pkg/apis/nais.io/v1alpha1/application_types.go
+++ b/pkg/apis/nais.io/v1alpha1/application_types.go
@@ -106,6 +106,8 @@ type TokenX struct {
 type AzureApplication struct {
 	Enabled   bool     `json:"enabled"`
 	ReplyURLs []string `json:"replyURLs,omitempty"`
+	// +kubebuilder:validation:Enum=nav.no;trygdeetaten.no
+	Tenant string `json:"tenant,omitempty"`
 }
 
 type SecureLogs struct {

--- a/pkg/resourcecreator/testdata/azureadapplication_full.yaml
+++ b/pkg/resourcecreator/testdata/azureadapplication_full.yaml
@@ -33,6 +33,7 @@ input:
     ingresses:
       - https://my.application/foo/bar
       - https://my.application/foo/bar/baz
+    tenant: nav.no
 
 tests:
   - apiVersion: nais.io/v1
@@ -57,3 +58,4 @@ tests:
             replyUrls:
               - url: "https://my.application/foo/bar/oauth2/callback"
               - url: "https://my.application/foo/bar/baz/oauth2/callback"
+            tenant: nav.no

--- a/pkg/resourcecreator/testdata/azureadapplication_minimal.yaml
+++ b/pkg/resourcecreator/testdata/azureadapplication_minimal.yaml
@@ -29,13 +29,14 @@ tests:
     operation: CreateOrUpdate
     match:
       - type: exact
-        name: "spec contains only secretName and nothing else"
+        name: "spec contains only secretName and tenant and nothing else"
         exclude:
           - .status
           - .metadata
           - .spec.secretName
         resource:
-          spec: {}
+          spec:
+            tenant: nav.no
 
   - apiVersion: nais.io/v1
     kind: AzureAdApplication

--- a/pkg/resourcecreator/testdata/azureadapplication_tenant.yaml
+++ b/pkg/resourcecreator/testdata/azureadapplication_tenant.yaml
@@ -1,0 +1,36 @@
+config:
+  description: azure application with explicitly targeted tenant
+
+resourceoptions:
+  AccessPolicy: true
+  GoogleProjectID: google-project-id
+  NumReplicas: 1
+  ClusterName: mycluster
+  AzureratorEnabled: true
+
+input:
+  kind: Application
+  apiVersion: v1alpha1
+  metadata:
+    name: myapplication
+    namespace: mynamespace
+    labels:
+      team: myteam
+  spec:
+    image: foo/bar
+    azure:
+      application:
+        enabled: true
+        tenant: trygdeetaten.no
+
+tests:
+  - apiVersion: nais.io/v1
+    kind: AzureAdApplication
+    name: myapplication
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "tenant is set"
+        resource:
+          spec:
+            tenant: trygdeetaten.no


### PR DESCRIPTION
Allow user-configurable Azure AD tenant target. Empty field results in no annotation which is treated as before - the logic for this exists in azurerator