### PR TITLE
Omit invalid method

### DIFF
--- a/pkg/resourcecreator/authorizationpolicy.go
+++ b/pkg/resourcecreator/authorizationpolicy.go
@@ -53,7 +53,6 @@ func ingressGatewayRule() *istio.Rule {
 		To: []*istio.Rule_To{
 			{
 				Operation: &istio.Operation{
-					Methods: []string{"*"},
 					Paths:   []string{"*"},
 				},
 			},
@@ -73,7 +72,6 @@ func accessPolicyRules(app *nais.Application, options ResourceOptions) *istio.Ru
 		To: []*istio.Rule_To{
 			{
 				Operation: &istio.Operation{
-					Methods: []string{"*"},
 					Paths:   []string{"*"},
 				},
 			},

--- a/pkg/resourcecreator/testdata/accesspolicy_gcp.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_gcp.yaml
@@ -18,6 +18,8 @@ input:
       team: myteam
   spec:
     image: navikt/myapplication:1.2.3
+    ingresses:
+      - 'https://myapplication.dev.adeo.no'
     accessPolicy:
       inbound:
         rules:
@@ -70,6 +72,13 @@ tests:
                     namespaceSelector:
                       matchLabels:
                         name: t1
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        name: istio-system
+                    podSelector:
+                      matchLabels:
+                        istio: ingressgateway
             egress:
               - to:
                   - podSelector:
@@ -141,13 +150,19 @@ tests:
               - from:
                   - source:
                       principals:
+                        - 'cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account'
+                to:
+                  - operation:
+                      paths:
+                        - '*'
+              - from:
+                  - source:
+                      principals:
                         - cluster.local/ns/mynamespace/sa/app1
                         - cluster.local/ns/q1/sa/app2
                         - cluster.local/ns/t1/sa/*
                 to:
                   - operation:
-                      methods:
-                        - '*'
                       paths:
                         - '*'
 


### PR DESCRIPTION
naiserator erroneously specifies `methods: ['*']`. This field is only supposed to consist of a list of HTTP/gRPC methods. The correct way to specify all methods allowed is to omit the parameter completely.

https://istio.io/latest/docs/reference/config/security/authorization-policy/

This fixes the generation of "KIA0102 Only HTTP methods and fully-qualified gRPC" errors on naiserator-generated AuthorizationPolicies.