### PR TITLE
Fix: Fjernet name i service.port

### DIFF
--- a/pkg/resourcecreator/service.go
+++ b/pkg/resourcecreator/service.go
@@ -19,7 +19,6 @@ func Service(app *nais.Application) *corev1.Service {
 			Selector: map[string]string{"app": app.Name},
 			Ports: []corev1.ServicePort{
 				{
-					Name:     nais.DefaultPortName,
 					Protocol: corev1.ProtocolTCP,
 					Port:     app.Spec.Service.Port,
 					TargetPort: intstr.IntOrString{

--- a/pkg/resourcecreator/testdata/vanilla_gcp.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_gcp.yaml
@@ -48,7 +48,6 @@ tests:
             ports:
               - port: 80
                 targetPort: http
-                name: http
                 protocol: TCP
             selector:
               app: myapplication

--- a/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
@@ -46,7 +46,6 @@ tests:
             ports:
               - port: 80
                 targetPort: http
-                name: http
                 protocol: TCP
             selector:
               app: myapplication


### PR DESCRIPTION
Viser seg at Istio leser name satt for service.port, og siden vi setter den til http blir protokollen feil.
Enkleste løsning er å fjerne navnet, da det ikke virker som om vi bruker den til andre ting.

Co-author-by: x10an14 <christian.chavez@nav.no>
Fixes #200 