### PR TITLE
Create istio proxy annotation

### DIFF
--- a/pkg/resourcecreator/deployment.go
+++ b/pkg/resourcecreator/deployment.go
@@ -447,6 +447,12 @@ func envVars(app *nais.Application) []corev1.EnvVar {
 	return newEnvVars
 }
 
+const tracingAnnotation = `tracing:
+  sampling: 0
+  zipkin:
+    address: zipkin.istio-system:9411
+`
+
 func podObjectMeta(app *nais.Application) metav1.ObjectMeta {
 	objectMeta := app.CreateObjectMeta()
 
@@ -460,6 +466,7 @@ func podObjectMeta(app *nais.Application) metav1.ObjectMeta {
 		"prometheus.io/port":   port,
 		"prometheus.io/path":   app.Spec.Prometheus.Path,
 	}
+
 	if len(app.Spec.Logformat) > 0 {
 		objectMeta.Annotations["nais.io/logformat"] = app.Spec.Logformat
 	}
@@ -473,11 +480,7 @@ func podObjectMeta(app *nais.Application) metav1.ObjectMeta {
 	}
 
 	if (app.Spec.Tracing != nil && app.Spec.Tracing.Enabled) {
-		objectMeta.Annotations["proxy.istio.io/config"] =
-                    "tracing:\n" +
-                    "  sampling: 0\n" +
-                    "  zipkin:\n" +
-                    "    address: zipkin.istio-system:9411\n"
+		objectMeta.Annotations["proxy.istio.io/config"] = tracingAnnotation
 	}
 
 	return objectMeta

--- a/pkg/resourcecreator/deployment.go
+++ b/pkg/resourcecreator/deployment.go
@@ -472,6 +472,14 @@ func podObjectMeta(app *nais.Application) metav1.ObjectMeta {
 		objectMeta.Labels["kafka"] = "enabled"
 	}
 
+	if (app.Spec.Tracing != nil && app.Spec.Tracing.Enabled) {
+		objectMeta.Annotations["proxy.istio.io/config"] =
+                    "tracing:\n" +
+                    "  sampling: 0\n" +
+                    "  zipkin:\n" +
+                    "    address: zipkin.istio-system:9411\n"
+	}
+
 	return objectMeta
 }
 

--- a/pkg/resourcecreator/testdata/tracing.yaml
+++ b/pkg/resourcecreator/testdata/tracing.yaml
@@ -1,5 +1,5 @@
 config:
-  description: egress to jaeger allowed when tracing enabled
+  description: Tracing is configured
 
 resourceoptions:
   AccessPolicy: true
@@ -35,3 +35,20 @@ tests:
                   podSelector:
                     matchLabels:
                       app: jaeger
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: myapplication
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "istio proxy configured to send traces to Zipkin"
+        resource:
+          spec:
+            template:
+              metadata:
+                annotations:
+                  proxy.istio.io/config: |
+                    tracing:
+                      sampling: 0
+                      zipkin:
+                        address: zipkin.istio-system:9411


### PR DESCRIPTION
tracing == 0 because tracing is still propagated if the span ID headers are generated by the library in question.

Generation of these headers might be a useful feature in the future.