### PR TITLE
fix: ensure that istio access policy rules have non-empty sources

### DIFF
--- a/pkg/resourcecreator/authorizationpolicy.go
+++ b/pkg/resourcecreator/authorizationpolicy.go
@@ -59,7 +59,10 @@ func AuthorizationPolicy(app *nais.Application, options ResourceOptions) (*istio
 	}
 
 	if len(app.Spec.AccessPolicy.Inbound.Rules) > 0 {
-		rules = append(rules, accessPolicyRules(app, options))
+		accessPolicyRules := accessPolicyRules(app, options)
+		if accessPolicyRules != nil {
+			rules = append(rules, accessPolicyRules)
+		}
 	}
 
 	if len(rules) == 0 {
@@ -111,11 +114,15 @@ func ingressGatewayRule(gateways []string) *istio.Rule {
 }
 
 func accessPolicyRules(app *nais.Application, options ResourceOptions) *istio.Rule {
+	principals := principals(app, options)
+	if len(principals) < 1 {
+		return nil
+	}
 	return &istio.Rule{
 		From: []*istio.Rule_From{
 			{
 				Source: &istio.Source{
-					Principals: principals(app, options),
+					Principals: principals,
 				},
 			},
 		},

--- a/pkg/resourcecreator/authorizationpolicy_test.go
+++ b/pkg/resourcecreator/authorizationpolicy_test.go
@@ -19,6 +19,7 @@ func TestGetAuthorizationPolicy(t *testing.T) {
 	otherNamespace2 := "othernamespace2"
 	resourceOptions := resourcecreator.NewResourceOptions()
 	resourceOptions.GatewayMappings = []config.GatewayMapping{{DomainSuffix: ".test.no", GatewayName: "istio-system/gw-test"}}
+	resourceOptions.ClusterName = "test-cluster"
 
 	t.Run("auth policy with no ingresses or access policies", func(t *testing.T) {
 		app := fixtures.MinimalApplication()
@@ -71,5 +72,12 @@ func TestGetAuthorizationPolicy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, authorizationPolicy.Spec.Rules, 1)
 		assert.Len(t, authorizationPolicy.Spec.Rules[0].From[0].Source.Principals, 2)
+	})
+	t.Run("auth policy for app with inbound access policy containing only non-local principals", func(t *testing.T) {
+		app := fixtures.MinimalApplication()
+		app.Spec.AccessPolicy.Inbound.Rules = []nais.AccessPolicyRule{{otherApplication, otherNamespace, "non-local"}}
+		authorizationPolicy, err := resourcecreator.AuthorizationPolicy(app, resourceOptions)
+		assert.NoError(t, err)
+		assert.Nil(t, authorizationPolicy)
 	})
 }


### PR DESCRIPTION
If an application _only_ defines an inbound access policy rule for a non-local application (i.e. the application belongs to a different cluster), we should not create an istio authorization policy as the rule contains an empty `from.source`.

That is, this:

```yaml
accessPolicy:
  inbound:
    rules:
      - application: hjelpemidlerdigitalsoknad-api
        namespace: teamdigihot
        cluster: dev-fss
```

results in this:

```
admission webhook "validation.istio.io" denied the request: configuration is invalid: `from.source` must not be empty, found at rule 2 in digihot-altinn-proxy.teamdigihot" 
```

This PR fixes this by only appending a rule to the authorization policy if the list of inbound principals is non-empty.