### PR TITLE
create google serviceaccounts for all gcp deployments by default

### DIFF
--- a/pkg/resourcecreator/resourcecreator.go
+++ b/pkg/resourcecreator/resourcecreator.go
@@ -70,13 +70,13 @@ func Create(app *nais.Application, resourceOptions ResourceOptions) (ResourceOpe
 		resourceOptions.DigdiratorSecretName = idportenClient.Spec.SecretName
 	}
 
-	if len(resourceOptions.GoogleProjectId) > 0 && app.Spec.GCP != nil {
+	if len(resourceOptions.GoogleProjectId) > 0 {
 		googleServiceAccount := GoogleIAMServiceAccount(app, resourceOptions.GoogleProjectId)
 		googleServiceAccountBinding := GoogleIAMPolicy(app, &googleServiceAccount, resourceOptions.GoogleProjectId)
 		ops = append(ops, ResourceOperation{&googleServiceAccount, OperationCreateOrUpdate})
 		ops = append(ops, ResourceOperation{&googleServiceAccountBinding, OperationCreateOrUpdate})
 
-		if app.Spec.GCP.Buckets != nil && len(app.Spec.GCP.Buckets) > 0 {
+		if app.Spec.GCP != nil && app.Spec.GCP.Buckets != nil && len(app.Spec.GCP.Buckets) > 0 {
 			for _, b := range app.Spec.GCP.Buckets {
 				bucket := GoogleStorageBucket(app, b)
 				ops = append(ops, ResourceOperation{bucket, OperationCreateIfNotExists})
@@ -86,7 +86,7 @@ func Create(app *nais.Application, resourceOptions ResourceOptions) (ResourceOpe
 			}
 		}
 
-		if app.Spec.GCP.SqlInstances != nil {
+		if app.Spec.GCP != nil && app.Spec.GCP.SqlInstances != nil {
 			vars := make(map[string]string)
 
 			for i, sqlInstance := range app.Spec.GCP.SqlInstances {

--- a/pkg/resourcecreator/testdata/vanilla_gcp.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_gcp.yaml
@@ -142,3 +142,43 @@ tests:
             podSelector:
               matchLabels:
                 app: myapplication
+
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "IAMServiceAccount created in namespace serviceaccounts"
+        exclude:
+          - .metadata.creationTimestamp
+        resource:
+          metadata:
+            annotations:
+              cnrm.cloud.google.com/project-id: google-project-id
+              nais.io/team: mynamespace
+            name: myapplicati-mynamespac-w4o5cwa
+            namespace: serviceaccounts
+          spec:
+            displayName: myapplication
+
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMPolicy
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "IAMPolicy created in namespace serviceaccounts"
+        resource:
+          metadata:
+            annotations:
+              cnrm.cloud.google.com/project-id: google-project-id
+            name: myapplicati-mynamespac-w4o5cwa
+            namespace: serviceaccounts
+          spec:
+            bindings:
+              - members:
+                  - serviceAccount:google-project-id.svc.id.goog[mynamespace/myapplication]
+                role: roles/iam.workloadIdentityUser
+            resourceRef:
+              apiVersion: iam.cnrm.cloud.google.com/v1beta1
+              kind: IAMServiceAccount
+              name: myapplicati-mynamespac-w4o5cwa


### PR DESCRIPTION
Some applications need a workload identity outside of buckets/sqlinstances that can be assigned permissions out-of-band to another project that owns some centrally managed resources.