### PR TITLE
Support multiple hosts on the same ingress gw

### DIFF
--- a/pkg/resourcecreator/ingress.go
+++ b/pkg/resourcecreator/ingress.go
@@ -179,13 +179,17 @@ func NginxIngresses(app *nais.Application, options ResourceOptions) ([]*networki
 	ingresses := make(map[string]*networkingv1beta1.Ingress)
 
 	for _, rule := range rules {
-		ingress := ingresses[rule.Host]
+		ingressClass := ResolveIngressClass(rule.Host, options.GatewayMappings)
+		if ingressClass == nil {
+			return nil, fmt.Errorf("domain '%s' is not supported", rule.Host)
+		}
+		ingress := ingresses[*ingressClass]
 		if ingress == nil {
 			ingress, err = createIngressBase(rule.Host)
 			if err != nil {
 				return nil, err
 			}
-			ingresses[rule.Host] = ingress
+			ingresses[*ingressClass] = ingress
 		}
 		ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
 	}

--- a/pkg/resourcecreator/testdata/ingress_linkerd.yaml
+++ b/pkg/resourcecreator/testdata/ingress_linkerd.yaml
@@ -20,6 +20,7 @@ input:
       team: myteam
   spec:
     ingresses:
+      - https://baz.bar
       - https://foo.bar
       - https://foo.bar/baz
       - https://bar.baz/foo
@@ -50,6 +51,13 @@ tests:
               nginx.ingress.kubernetes.io/backend-protocol: HTTP
           spec:
             rules:
+              - host: baz.bar
+                http:
+                  paths:
+                    - backend:
+                        serviceName: myapplication
+                        servicePort: 80
+                      path: /
               - host: foo.bar
                 http:
                   paths:


### PR DESCRIPTION
If multiple ingresses on the same gateway are specified, they will now
overwrite each other in the `ingresses` map because `host` is used as
map key, while the `ingressClass` is used in the ingress resource name.

This fix uses the `ingressClass` as key for the `ingresses` map.