### PR TITLE
fix(google/sql): ensure that resource ID is set for additional users

### DIFF
--- a/pkg/resourcecreator/google/sql/user.go
+++ b/pkg/resourcecreator/google/sql/user.go
@@ -108,12 +108,14 @@ func (in GoogleSqlUser) isDefault() bool {
 
 func (in GoogleSqlUser) Create(objectMeta metav1.ObjectMeta, secretKeyRefEnvName string, cascadingDelete bool, projectId string) (*googlesqlcrd.SQLUser, error) {
 	appName := objectMeta.Name
+
 	objectDataName, err := in.uniqueObjectName()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create meatadata: %s", err)
 	}
 	objectMeta.Name = objectDataName
 	setAnnotations(objectMeta, cascadingDelete, projectId)
+
 	return in.create(objectMeta, secretKeyRefEnvName, appName), nil
 }
 
@@ -126,7 +128,7 @@ func (in GoogleSqlUser) uniqueObjectName() (string, error) {
 }
 
 func (in GoogleSqlUser) create(objectMeta metav1.ObjectMeta, secretKeyRefEnvName, appName string) *googlesqlcrd.SQLUser {
-	return &googlesqlcrd.SQLUser{
+	sqluser := &googlesqlcrd.SQLUser{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "SQLUser",
 			APIVersion: "sql.cnrm.cloud.google.com/v1beta1",
@@ -144,6 +146,12 @@ func (in GoogleSqlUser) create(objectMeta metav1.ObjectMeta, secretKeyRefEnvName
 			},
 		},
 	}
+
+	if !in.isDefault() {
+		sqluser.Spec.ResourceID = in.Name
+	}
+
+	return sqluser
 }
 
 func setAnnotations(objectMeta metav1.ObjectMeta, cascadingDelete bool, projectId string) {

--- a/pkg/resourcecreator/testdata/gcp_database_additional_users.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database_additional_users.yaml
@@ -155,6 +155,7 @@ tests:
                 secretKeyRef:
                   name: google-sql-myapplication
                   key: NAIS_DATABASE_MYAPPLICATION_MYDB_PASSWORD
+
   - apiVersion: sql.cnrm.cloud.google.com/v1beta1
     kind: SQLUser
     operation: CreateIfNotExists
@@ -178,6 +179,8 @@ tests:
                 secretKeyRef:
                   name: google-sql-myapplication-user-two
                   key: NAIS_DATABASE_USER_TWO_MYDB_PASSWORD
+            resourceID: User_two
+
   - apiVersion: sql.cnrm.cloud.google.com/v1beta1
     kind: SQLUser
     operation: CreateIfNotExists
@@ -201,3 +204,4 @@ tests:
                 secretKeyRef:
                   name: google-sql-myapplication-user-three3
                   key: NAIS_DATABASE_USER_THREE3_MYDB_PASSWORD
+            resourceID: _user_three3

--- a/pkg/resourcecreator/testdata/gcp_database_additional_users.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database_additional_users.yaml
@@ -53,7 +53,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-myapplication
             namespace: mynamespace
             labels:
               app: myapplication
@@ -83,7 +82,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-myapplication-user-two
             namespace: mynamespace
             labels:
               app: myapplication
@@ -113,7 +111,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-myapplication-user-three3
             namespace: mynamespace
             labels:
               app: myapplication
@@ -141,7 +138,6 @@ tests:
         name: "additional - sql user: myapplication"
         resource:
           metadata:
-            name: myapplication
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon
@@ -165,7 +161,6 @@ tests:
         name: "sql user: user-two"
         resource:
           metadata:
-            name: additional
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon
@@ -190,7 +185,6 @@ tests:
         name: "sql user: user-three"
         resource:
           metadata:
-            name: extra
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon

--- a/pkg/resourcecreator/testdata/gcp_database_custom_env_additional_users.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database_custom_env_additional_users.yaml
@@ -8,16 +8,16 @@ resourceoptions:
   NumReplicas: 1
 
 input:
-  kind: Naisjob
-  apiVersion: nais.io/v1
+  kind: Application
+  apiVersion: v1alpha1
   metadata:
-    name: mynaisjob
+    name: myapplication
     namespace: mynamespace
     uid: "123456"
     labels:
       team: myteam
   spec:
-    image: navikt/mynaisjob:1.2.3
+    image: navikt/myapplication:1.2.3
     gcp:
       sqlInstances:
         - databases:
@@ -34,18 +34,18 @@ tests:
         resource:
           metadata:
             labels:
-              app: mynaisjob
+              app: myapplication
               team: myteam
             ownerReferences:
-              - apiVersion: v1
-                kind: Naisjob
-                name: mynaisjob
+              - apiVersion: v1alpha1
+                kind: Application
+                name: myapplication
                 uid: "123456"
 
   - apiVersion: v1
     kind: Secret
     operation: CreateIfNotExists
-    name: google-sql-mynaisjob
+    name: google-sql-myapplication
     match:
       - type: regex
         name: "secret default"
@@ -53,29 +53,29 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-mynaisjob
+            name: google-sql-myapplication
             namespace: mynamespace
             labels:
-              app: mynaisjob
+              app: myapplication
               team: myteam
             ownerReferences:
-              - apiVersion: v1
-                kind: Naisjob
-                name: mynaisjob
+              - kind: Application
+                name: myapplication
                 uid: "123456"
+                apiVersion: v1alpha1
           stringData:
             PWNED_DATABASE: mydb
             PWNED_HOST: 127.0.0.1
             PWNED_PASSWORD: ".{43}"
             PWNED_PORT: "5432"
-            PWNED_URL: postgres://mynaisjob:.{43}@127.0.0.1:5432/mydb
-            PWNED_USERNAME: mynaisjob
+            PWNED_URL: postgres://myapplication:.{43}@127.0.0.1:5432/mydb
+            PWNED_USERNAME: myapplication
           type: Opaque
 
   - apiVersion: v1
     kind: Secret
     operation: CreateIfNotExists
-    name: google-sql-mynaisjob-user-two
+    name: google-sql-myapplication-user-two
     match:
       - type: regex
         name: "secret two"
@@ -83,16 +83,16 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-mynaisjob-user-two
+            name: google-sql-myapplication-user-two
             namespace: mynamespace
             labels:
-              app: mynaisjob
+              app: myapplication
               team: myteam
             ownerReferences:
-              - apiVersion: v1
-                kind: Naisjob
-                name: mynaisjob
+              - kind: Application
+                name: myapplication
                 uid: "123456"
+                apiVersion: v1alpha1
           stringData:
             PWNED_USER_TWO_DATABASE: mydb
             PWNED_USER_TWO_HOST: 127.0.0.1
@@ -105,31 +105,31 @@ tests:
   - apiVersion: sql.cnrm.cloud.google.com/v1beta1
     kind: SQLUser
     operation: CreateIfNotExists
-    name: mynaisjob
+    name: myapplication
     match:
       - type: subset
         name: "custom env - sql user: myapplication"
         resource:
           metadata:
-            name: mynaisjob
+            name: myapplication
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon
               cnrm.cloud.google.com/project-id: team-project-id
           spec:
             instanceRef:
-              name: mynaisjob
+              name: myapplication
             host: ""
             password:
               valueFrom:
                 secretKeyRef:
-                  name: google-sql-mynaisjob
+                  name: google-sql-myapplication
                   key: PWNED_PASSWORD
 
   - apiVersion: sql.cnrm.cloud.google.com/v1beta1
     kind: SQLUser
     operation: CreateIfNotExists
-    name: mynaisjob-user-two-48e70ce1
+    name: myapplication-user-two-df860d3e
     match:
       - type: subset
         name: "custom env - sql user: user-two"
@@ -142,10 +142,11 @@ tests:
               cnrm.cloud.google.com/project-id: team-project-id
           spec:
             instanceRef:
-              name: mynaisjob
+              name: myapplication
             host: ""
             password:
               valueFrom:
                 secretKeyRef:
-                  name: google-sql-mynaisjob-user-two
+                  name: google-sql-myapplication-user-two
                   key: PWNED_USER_TWO_PASSWORD
+            resourceID: user_two

--- a/pkg/resourcecreator/testdata/gcp_database_custom_env_additional_users.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database_custom_env_additional_users.yaml
@@ -53,7 +53,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-myapplication
             namespace: mynamespace
             labels:
               app: myapplication
@@ -83,7 +82,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-myapplication-user-two
             namespace: mynamespace
             labels:
               app: myapplication
@@ -111,7 +109,6 @@ tests:
         name: "custom env - sql user: myapplication"
         resource:
           metadata:
-            name: myapplication
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon
@@ -135,7 +132,6 @@ tests:
         name: "custom env - sql user: user-two"
         resource:
           metadata:
-            name: user-two
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_additional_users.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_additional_users.yaml
@@ -53,7 +53,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-mynaisjob
             namespace: mynamespace
             labels:
               app: mynaisjob
@@ -83,7 +82,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-mynaisjob-user-two
             namespace: mynamespace
             labels:
               app: mynaisjob
@@ -113,7 +111,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-mynaisjob-user-three3
             namespace: mynamespace
             labels:
               app: mynaisjob
@@ -141,7 +138,6 @@ tests:
         name: "additional - sql user: mynaisjob"
         resource:
           metadata:
-            name: mynaisjob
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon
@@ -165,7 +161,6 @@ tests:
         name: "sql user: user-two"
         resource:
           metadata:
-            name: additional
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon
@@ -190,7 +185,6 @@ tests:
         name: "sql user: user-three"
         resource:
           metadata:
-            name: extra
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_additional_users.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_additional_users.yaml
@@ -179,6 +179,7 @@ tests:
                 secretKeyRef:
                   name: google-sql-mynaisjob-user-two
                   key: NAIS_DATABASE_USER_TWO_MYDB_PASSWORD
+            resourceID: User_two
 
   - apiVersion: sql.cnrm.cloud.google.com/v1beta1
     kind: SQLUser
@@ -203,3 +204,4 @@ tests:
                 secretKeyRef:
                   name: google-sql-mynaisjob-user-three3
                   key: NAIS_DATABASE_USER_THREE3_MYDB_PASSWORD
+            resourceID: _user_three3

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_custom_env_additional_users.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_custom_env_additional_users.yaml
@@ -53,7 +53,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-mynaisjob
             namespace: mynamespace
             labels:
               app: mynaisjob
@@ -83,7 +82,6 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-mynaisjob-user-two
             namespace: mynamespace
             labels:
               app: mynaisjob
@@ -111,7 +109,6 @@ tests:
         name: "custom env - sql user: myapplication"
         resource:
           metadata:
-            name: mynaisjob
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon
@@ -135,7 +132,6 @@ tests:
         name: "custom env - sql user: user-two"
         resource:
           metadata:
-            name: user-two
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_custom_env_additional_users.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_custom_env_additional_users.yaml
@@ -8,16 +8,16 @@ resourceoptions:
   NumReplicas: 1
 
 input:
-  kind: Application
-  apiVersion: v1alpha1
+  kind: Naisjob
+  apiVersion: nais.io/v1
   metadata:
-    name: myapplication
+    name: mynaisjob
     namespace: mynamespace
     uid: "123456"
     labels:
       team: myteam
   spec:
-    image: navikt/myapplication:1.2.3
+    image: navikt/mynaisjob:1.2.3
     gcp:
       sqlInstances:
         - databases:
@@ -34,18 +34,18 @@ tests:
         resource:
           metadata:
             labels:
-              app: myapplication
+              app: mynaisjob
               team: myteam
             ownerReferences:
-              - apiVersion: v1alpha1
-                kind: Application
-                name: myapplication
+              - apiVersion: v1
+                kind: Naisjob
+                name: mynaisjob
                 uid: "123456"
 
   - apiVersion: v1
     kind: Secret
     operation: CreateIfNotExists
-    name: google-sql-myapplication
+    name: google-sql-mynaisjob
     match:
       - type: regex
         name: "secret default"
@@ -53,29 +53,29 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-myapplication
+            name: google-sql-mynaisjob
             namespace: mynamespace
             labels:
-              app: myapplication
+              app: mynaisjob
               team: myteam
             ownerReferences:
-              - kind: Application
-                name: myapplication
+              - apiVersion: v1
+                kind: Naisjob
+                name: mynaisjob
                 uid: "123456"
-                apiVersion: v1alpha1
           stringData:
             PWNED_DATABASE: mydb
             PWNED_HOST: 127.0.0.1
             PWNED_PASSWORD: ".{43}"
             PWNED_PORT: "5432"
-            PWNED_URL: postgres://myapplication:.{43}@127.0.0.1:5432/mydb
-            PWNED_USERNAME: myapplication
+            PWNED_URL: postgres://mynaisjob:.{43}@127.0.0.1:5432/mydb
+            PWNED_USERNAME: mynaisjob
           type: Opaque
 
   - apiVersion: v1
     kind: Secret
     operation: CreateIfNotExists
-    name: google-sql-myapplication-user-two
+    name: google-sql-mynaisjob-user-two
     match:
       - type: regex
         name: "secret two"
@@ -83,16 +83,16 @@ tests:
           - metadata.creationTimestamp
         resource:
           metadata:
-            name: google-sql-myapplication-user-two
+            name: google-sql-mynaisjob-user-two
             namespace: mynamespace
             labels:
-              app: myapplication
+              app: mynaisjob
               team: myteam
             ownerReferences:
-              - kind: Application
-                name: myapplication
+              - apiVersion: v1
+                kind: Naisjob
+                name: mynaisjob
                 uid: "123456"
-                apiVersion: v1alpha1
           stringData:
             PWNED_USER_TWO_DATABASE: mydb
             PWNED_USER_TWO_HOST: 127.0.0.1
@@ -105,30 +105,31 @@ tests:
   - apiVersion: sql.cnrm.cloud.google.com/v1beta1
     kind: SQLUser
     operation: CreateIfNotExists
-    name: myapplication
+    name: mynaisjob
     match:
       - type: subset
         name: "custom env - sql user: myapplication"
         resource:
           metadata:
-            name: myapplication
+            name: mynaisjob
             namespace: mynamespace
             annotations:
               cnrm.cloud.google.com/deletion-policy: abandon
               cnrm.cloud.google.com/project-id: team-project-id
           spec:
             instanceRef:
-              name: myapplication
+              name: mynaisjob
             host: ""
             password:
               valueFrom:
                 secretKeyRef:
-                  name: google-sql-myapplication
+                  name: google-sql-mynaisjob
                   key: PWNED_PASSWORD
+
   - apiVersion: sql.cnrm.cloud.google.com/v1beta1
     kind: SQLUser
     operation: CreateIfNotExists
-    name: myapplication-user-two-df860d3e
+    name: mynaisjob-user-two-48e70ce1
     match:
       - type: subset
         name: "custom env - sql user: user-two"
@@ -141,10 +142,11 @@ tests:
               cnrm.cloud.google.com/project-id: team-project-id
           spec:
             instanceRef:
-              name: myapplication
+              name: mynaisjob
             host: ""
             password:
               valueFrom:
                 secretKeyRef:
-                  name: google-sql-myapplication-user-two
+                  name: google-sql-mynaisjob-user-two
                   key: PWNED_USER_TWO_PASSWORD
+            resourceID: user_two


### PR DESCRIPTION
As per https://cloud.google.com/config-connector/docs/reference/resource-docs/sql/sqluser,
the default behaviour for SQLUser is to use `metadata.name` as the name
of the SQL user. We've set this to be `$sqlinstance-$clean(user)-$hash` for
any additional users. However, this results in a mismatch between the
actual SQL username that is provisioned and the desired username
(the latter of which is also used in the generated secret) - and
ultimately causes authentication errors.

This commit fixes this by specifying the `resourceID` field and setting
the value of this to the desired username for additional users only.