### PR TITLE
fix(poddisruptionbudget): use maxUnavailable instead of minAvailable

### DIFF
--- a/pkg/resourcecreator/poddisruptionbudget/poddisruptionbudget.go
+++ b/pkg/resourcecreator/poddisruptionbudget/poddisruptionbudget.go
@@ -13,7 +13,7 @@ func Create(source resource.Source, ast *resource.Ast, naisReplicas nais_io_v1.R
 		return
 	}
 
-	min := intstr.FromInt(naisReplicas.Min)
+	maxUnavailable := intstr.FromInt(1)
 
 	podDisruptionBudget := &policyv1beta1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
@@ -22,7 +22,7 @@ func Create(source resource.Source, ast *resource.Ast, naisReplicas nais_io_v1.R
 		},
 		ObjectMeta: resource.CreateObjectMeta(source),
 		Spec: policyv1beta1.PodDisruptionBudgetSpec{
-			MinAvailable: &min,
+			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": source.GetName(),

--- a/pkg/resourcecreator/testdata/vanilla_gcp.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_gcp.yaml
@@ -193,13 +193,13 @@ tests:
     name: myapplication
     match:
       - type: exact
-        name: "pdb created with 2 min available"
+        name: "pdb created with 1 max unavailable"
         exclude:
           - .metadata
           - .status
         resource:
           spec:
-            minAvailable: 2
+            maxUnavailable: 1
             selector:
               matchLabels:
                 app: myapplication

--- a/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
@@ -209,13 +209,13 @@ tests:
     name: myapplication
     match:
       - type: exact
-        name: "pdb created with 2 min available"
+        name: "pdb created with 1 max unavailable"
         exclude:
           - .metadata
           - .status
         resource:
           spec:
-            minAvailable: 2
+            maxUnavailable: 1
             selector:
               matchLabels:
                 app: myapplication


### PR DESCRIPTION
Previously, we set `minAvailable` in the PDB to be equal to the minimum desired
replica count - which in most cases results in the PDB not allowing any
disruptions because `count(pods) == minAvailable`. This effectively
halts draining of nodes containing pods affected by these PDBs, and in
the case of GKE will force-delete these pods when the grace period of 1
hour passes.

By setting the `maxUnavailable` to 1 we allow for a maximum of 1 disrupted
pod during upgrades. This comes with the caveat of effectively disabling PDBs
for applications that have set the minimum replica count to 1 and have not been
scaled up by the HPA at the time of the drain. However, one could argue that
users desiring high availability of their applications should specify at least
2 minimum replicas.