### PR TITLE
restricted securitycontext as optin

### DIFF
--- a/pkg/resourcecreator/batch/job.go
+++ b/pkg/resourcecreator/batch/job.go
@@ -13,7 +13,8 @@ import (
 
 func CreateJobSpec(naisjob *nais_io_v1.Naisjob, ast *resource.Ast, resourceOptions resource.Options) (batchv1.JobSpec, error) {
 
-	podSpec, err := pod.CreateSpec(ast, resourceOptions, naisjob.Name, naisjob.Annotations, RestartPolicy(naisjob.Spec.RestartPolicy))
+	podSpec, err := pod.CreateSpec(ast, resourceOptions, naisjob.GetName(), naisjob.Annotations,
+		RestartPolicy(naisjob.Spec.RestartPolicy))
 	if err != nil {
 		return batchv1.JobSpec{}, err
 	}

--- a/pkg/resourcecreator/batch/job.go
+++ b/pkg/resourcecreator/batch/job.go
@@ -13,7 +13,7 @@ import (
 
 func CreateJobSpec(naisjob *nais_io_v1.Naisjob, ast *resource.Ast, resourceOptions resource.Options) (batchv1.JobSpec, error) {
 
-	podSpec, err := pod.CreateSpec(ast, resourceOptions, naisjob.GetName(), RestartPolicy(naisjob.Spec.RestartPolicy))
+	podSpec, err := pod.CreateSpec(ast, resourceOptions, naisjob.Name, naisjob.Annotations, RestartPolicy(naisjob.Spec.RestartPolicy))
 	if err != nil {
 		return batchv1.JobSpec{}, err
 	}

--- a/pkg/resourcecreator/deployment/deployment.go
+++ b/pkg/resourcecreator/deployment/deployment.go
@@ -62,7 +62,7 @@ func addCleanupLabels(app *nais_io_v1alpha1.Application, meta metav1.ObjectMeta)
 }
 
 func deploymentSpec(app *nais_io_v1alpha1.Application, ast *resource.Ast, resourceOptions resource.Options) (*appsv1.DeploymentSpec, error) {
-	podSpec, err := pod.CreateSpec(ast, resourceOptions, app.Name, corev1.RestartPolicyAlways)
+	podSpec, err := pod.CreateSpec(ast, resourceOptions, app.Name, app.Annotations, corev1.RestartPolicyAlways)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func deploymentSpec(app *nais_io_v1alpha1.Application, ast *resource.Ast, resour
 	}
 
 	return &appsv1.DeploymentSpec{
-		Replicas: util.Int32p(resourceOptions.NumReplicas),
+		Replicas: util.Int32p(int32(*app.Spec.Replicas.Min)),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{"app": app.Name},
 		},

--- a/pkg/resourcecreator/testdata/opt_in_securitycontext.yaml
+++ b/pkg/resourcecreator/testdata/opt_in_securitycontext.yaml
@@ -1,0 +1,44 @@
+config:
+  description: opt-in restricted securitycontext
+
+resourceoptions:
+  NumReplicas: 1
+  Linkerd: true
+  NetworkPolicy: true
+  GoogleProjectID: google-project-id
+
+input:
+  kind: Application
+  apiVersion: v1alpha1
+  metadata:
+    name: myapplication
+    namespace: mynamespace
+    uid: "123456"
+    labels:
+      team: myteam
+    annotations:
+      nais.io/restricted: true
+  spec:
+    image: navikt/myapplication:1.2.3
+tests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: myapplication
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "restricted securitycontext"
+        resource:
+          spec:
+            replicas: 2
+            template:
+              spec:
+                containers:
+                  - securityContext:
+                      runAsUser: 1069
+                      runAsGroup: 1069
+                      allowPrivilegeEscalation: false
+                      runAsNonRoot: true
+                      privileged: false
+                      capabilities:
+                        drop: ["all"]

--- a/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
@@ -104,7 +104,7 @@ tests:
           - .spec.template.metadata.creationTimestamp
         resource:
           spec:
-            replicas: 1
+            replicas: 2
             selector:
               matchLabels:
                 app: myapplication


### PR DESCRIPTION
Note: also fixes bug where if max == min, we set the replicas in the deployment to what is specified in resourceoptions. This didn't matter before as we always created HPA

Co-authored-by: Roger Bjørnstad <roger.bjornstad@nav.no>
Co-authored-by: Sten Ivar Røkke <sten.ivar.rokke@nav.no>