### PR TITLE
Add `kind` label to `metrics.ResourcesGenerated`.

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -55,11 +55,11 @@ var (
 		Namespace: "naiserator",
 		Help:      "number of nais.io.Application resources that failed synchronization and have been re-enqueued",
 	})
-	ResourcesGenerated = prometheus.NewCounter(prometheus.CounterOpts{
+	ResourcesGenerated = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name:      "resources_generated",
 		Namespace: "naiserator",
 		Help:      "number of Kubernetes resources that have been generated as a result of application deployments",
-	})
+	}, []string{"kind"})
 	KubernetesResourceWriteDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:      "kubernetes_resource_write_duration",
 		Namespace: "naiserator",


### PR DESCRIPTION
Modify synchronizer to add meta fields for cluster operation functions.

https://trello.com/c/XFcFczuY/74-legge-p%C3%A5-kind-label-p%C3%A5-resourceswritten-metrikken
