### PR TITLE
Create separate webhook executable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 naiserator.iml
 cmd/naiserator/naiserator
+cmd/naiserator_webhook/naiserator_webhook
 vendor/
 cover.out
 ./naiserator

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,18 @@ FROM golang:1.17-alpine as builder
 RUN apk add --no-cache git make curl
 ENV GOOS=linux
 ENV CGO_ENABLED=0
-ENV GO111MODULE=on
-COPY . /src
 WORKDIR /src
-RUN go get
+COPY go.* /src/
+RUN go mod download
+COPY . /src
 RUN make kubebuilder
 RUN go test ./...
 RUN cd cmd/naiserator && go build -a -installsuffix cgo -o naiserator
+RUN cd cmd/naiserator_webhook && go build -a -installsuffix cgo -o naiserator_webhook
 
 FROM alpine:3.14
 RUN apk add --no-cache ca-certificates
 WORKDIR /app
 COPY --from=builder /src/cmd/naiserator/naiserator /app/naiserator
+COPY --from=builder /src/cmd/naiserator_webhook/naiserator_webhook /app/naiserator_webhook
 CMD ["/app/naiserator"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ PROTOC = $(shell which protoc)
 .PHONY: build docker docker-push local install test proto
 
 build:
-	cd cmd/naiserator && go build
+	go build -o cmd/naiserator/naiserator ./cmd/naiserator
+	go build -o cmd/naiserator_webhook/naiserator_webhook ./cmd/naiserator_webhook
 
 docker:
 	docker image build -t ${TAG}:$(shell ./version.sh) -t ${TAG} -t ${NAME} -t ${LATEST} -f Dockerfile .

--- a/cmd/naiserator_webhook/main.go
+++ b/cmd/naiserator_webhook/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	liberator_scheme "github.com/nais/liberator/pkg/scheme"
+	"github.com/nais/naiserator/pkg/metrics"
+	"github.com/nais/naiserator/pkg/naiserator/config"
+	log "github.com/sirupsen/logrus"
+	ctrl "sigs.k8s.io/controller-runtime"
+	kubemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func main() {
+	err := run()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	log.Info("Naiserator webhook shutting down")
+}
+
+func run() error {
+	var err error
+
+	formatter := log.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	}
+	log.SetFormatter(&formatter)
+	log.SetLevel(log.DebugLevel)
+
+	log.Info("Naiserator webhook starting up")
+
+	cfg, err := config.New()
+	if err != nil {
+		return err
+	}
+
+	config.Print([]string{
+		"kafka.sasl.username",
+		"kafka.sasl.password",
+	})
+
+	// Register CRDs with controller-tools
+	kscheme, err := liberator_scheme.All()
+	if err != nil {
+		return err
+	}
+
+	kconfig, err := ctrl.GetConfig()
+	if err != nil {
+		return err
+	}
+	kconfig.QPS = float32(cfg.Ratelimit.QPS)
+	kconfig.Burst = cfg.Ratelimit.Burst
+
+	metrics.Register(kubemetrics.Registry)
+	mgr, err := ctrl.NewManager(kconfig, ctrl.Options{
+		Scheme:             kscheme,
+		MetricsBindAddress: cfg.Bind,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Register create/update validation webhooks for liberator_scheme's CRDs
+	if err := liberator_scheme.Webhooks(mgr); err != nil {
+		return err
+	}
+
+	stopCh := StopCh()
+	return mgr.Start(stopCh)
+}
+
+func StopCh() (stopCh <-chan struct{}) {
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGINT}...)
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}


### PR DESCRIPTION
After discussions on slack, we might want to separate the webhook server into a separate service. This creates a new binary in the dockerfile which allows to use similar workflow as the existing one, but running a separate deployment for webhook.

This requires some additional changes:
- Create new Deployment and Service
- Update Certificates to match the new service name
- Update ValidatingWebhookConfiguration with new CA Bundle and service

After the change, we can remove the feature gate code from the main executable. 