### PR TITLE
fix(poddisruptionbudget): skip creating PDB if min replicas is set to 1

### DIFF
--- a/pkg/resourcecreator/poddisruptionbudget/poddisruptionbudget.go
+++ b/pkg/resourcecreator/poddisruptionbudget/poddisruptionbudget.go
@@ -2,14 +2,15 @@ package poddisruptionbudget
 
 import (
 	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
-	"github.com/nais/naiserator/pkg/resourcecreator/resource"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/nais/naiserator/pkg/resourcecreator/resource"
 )
 
 func Create(source resource.Source, ast *resource.Ast, naisReplicas nais_io_v1.Replicas) {
-	if *naisReplicas.Max == 1 {
+	if *naisReplicas.Max == 1 || *naisReplicas.Min == 1 {
 		return
 	}
 

--- a/pkg/resourcecreator/poddisruptionbudget/poddisruptionbudget_test.go
+++ b/pkg/resourcecreator/poddisruptionbudget/poddisruptionbudget_test.go
@@ -3,11 +3,12 @@ package poddisruptionbudget_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/nais/naiserator/pkg/resourcecreator/poddisruptionbudget"
 	"github.com/nais/naiserator/pkg/resourcecreator/resource"
 	"github.com/nais/naiserator/pkg/test/fixtures"
 	"github.com/nais/naiserator/pkg/util"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPodDisruptionBudget(t *testing.T) {
@@ -15,6 +16,17 @@ func TestPodDisruptionBudget(t *testing.T) {
 		app := fixtures.MinimalApplication()
 		ast := resource.NewAst()
 		app.Spec.Replicas.Max = util.Intp(1)
+		err := app.ApplyDefaults()
+		assert.NoError(t, err)
+
+		poddisruptionbudget.Create(app, ast, *app.Spec.Replicas)
+		assert.Len(t, ast.Operations, 0)
+	})
+
+	t.Run("min replicas = 1 should not have pdb", func(t *testing.T) {
+		app := fixtures.MinimalApplication()
+		ast := resource.NewAst()
+		app.Spec.Replicas.Min = util.Intp(1)
 		err := app.ApplyDefaults()
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Currently, if a PDB is created with min replicas set to 1 and max > 1,
the PDB will disallow any disrupted pods if the deployment only has a
single active replica at the time of draining. This results in the
draining process of the node to halt, which is undesirable. Applications
requiring zero disruptions should specify minimum 2 replicas.