### PR TITLE
gcp/buckets: uniform bucket level access

### DIFF
--- a/pkg/resourcecreator/google/gcp/gcp.go
+++ b/pkg/resourcecreator/google/gcp/gcp.go
@@ -26,9 +26,11 @@ func Create(source resource.Source, ast *resource.Ast, resourceOptions resource.
 	ast.AppendOperation(resource.OperationCreateIfNotExists, &googleServiceAccountBinding)
 
 	if resourceOptions.CNRMEnabled && naisGCP != nil {
-		google_storagebucket.Create(source, ast, resourceOptions, googleServiceAccount, naisGCP.Buckets)
-
-		err := google_bigquery.CreateDataset(source, ast, resourceOptions, naisGCP.BigQueryDatasets, googleServiceAccount.Name)
+		err := google_storagebucket.Create(source, ast, resourceOptions, googleServiceAccount, naisGCP.Buckets)
+		if err != nil {
+			return err
+		}
+		err = google_bigquery.CreateDataset(source, ast, resourceOptions, naisGCP.BigQueryDatasets, googleServiceAccount.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/resourcecreator/testdata/gcp_buckets_uniformlevelaccess.yaml
+++ b/pkg/resourcecreator/testdata/gcp_buckets_uniformlevelaccess.yaml
@@ -82,6 +82,7 @@ tests:
   - apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMPolicyMember
     operation: CreateIfNotExists
+    name: myapplication-legacy-bucket-owner-bcdd5bed
     match:
       - type: subset
         name: "IAMPolicyMember created in namespace mynamespace"
@@ -89,7 +90,6 @@ tests:
           metadata:
             annotations:
               cnrm.cloud.google.com/project-id: team-project-id
-            name: myapplicati-mynamespac-w4o5cwa
             namespace: mynamespace
           spec:
             member: serviceAccount:myapplicati-mynamespac-w4o5cwa@google-project-id.iam.gserviceaccount.com
@@ -102,6 +102,7 @@ tests:
   - apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMPolicyMember
     operation: CreateIfNotExists
+    name: myapplication-legacy-object-owner-57077294
     match:
       - type: subset
         name: "IAMPolicyMember created in namespace mynamespace"
@@ -109,7 +110,6 @@ tests:
           metadata:
             annotations:
               cnrm.cloud.google.com/project-id: team-project-id
-            name: myapplicati-mynamespac-w4o5cwa
             namespace: mynamespace
           spec:
             member: serviceAccount:myapplicati-mynamespac-w4o5cwa@google-project-id.iam.gserviceaccount.com
@@ -121,6 +121,7 @@ tests:
   - apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMPolicyMember
     operation: CreateIfNotExists
+    name: myapplication-object-viewer-5ce746e8
     match:
       - type: subset
         name: "IAMPolicyMember created in namespace mynamespace"
@@ -128,7 +129,6 @@ tests:
           metadata:
             annotations:
               cnrm.cloud.google.com/project-id: team-project-id
-            name: myapplicati-mynamespac-w4o5cwa
             namespace: mynamespace
           spec:
             member: serviceAccount:myapplicati-mynamespac-w4o5cwa@google-project-id.iam.gserviceaccount.com

--- a/pkg/resourcecreator/testdata/gcp_buckets_uniformlevelaccess.yaml
+++ b/pkg/resourcecreator/testdata/gcp_buckets_uniformlevelaccess.yaml
@@ -93,6 +93,45 @@ tests:
             namespace: mynamespace
           spec:
             member: serviceAccount:myapplicati-mynamespac-w4o5cwa@google-project-id.iam.gserviceaccount.com
+            role: roles/storage.legacyBucketOwner
+            resourceRef:
+              apiVersion: storage.cnrm.cloud.google.com/v1beta1
+              kind: StorageBucket
+              name: myapplication
+
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMPolicyMember
+    operation: CreateIfNotExists
+    match:
+      - type: subset
+        name: "IAMPolicyMember created in namespace mynamespace"
+        resource:
+          metadata:
+            annotations:
+              cnrm.cloud.google.com/project-id: team-project-id
+            name: myapplicati-mynamespac-w4o5cwa
+            namespace: mynamespace
+          spec:
+            member: serviceAccount:myapplicati-mynamespac-w4o5cwa@google-project-id.iam.gserviceaccount.com
+            role: roles/storage.legacyObjectOwner
+            resourceRef:
+              apiVersion: storage.cnrm.cloud.google.com/v1beta1
+              kind: StorageBucket
+              name: myapplication
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMPolicyMember
+    operation: CreateIfNotExists
+    match:
+      - type: subset
+        name: "IAMPolicyMember created in namespace mynamespace"
+        resource:
+          metadata:
+            annotations:
+              cnrm.cloud.google.com/project-id: team-project-id
+            name: myapplicati-mynamespac-w4o5cwa
+            namespace: mynamespace
+          spec:
+            member: serviceAccount:myapplicati-mynamespac-w4o5cwa@google-project-id.iam.gserviceaccount.com
             role: roles/storage.objectViewer
             resourceRef:
               apiVersion: storage.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
Set up IAMPolicyMember for buckets with uniform-bucket-level-access, in addition to the existing role `roles/storage.objectViewer`:
* `roles/storage.legacyObjectOwner`
* `roles/storage.legacyBucketOwner`

The IAMPolicyMember resources are also given distinct names to avoid naming collisions and length limitations.