### PR TITLE
Rewrite image tags

### DIFF
--- a/pkg/resourcecreator/pod/pod.go
+++ b/pkg/resourcecreator/pod/pod.go
@@ -235,7 +235,7 @@ func CreateAppContainer(app Source, ast *resource.Ast, cfg Config) error {
 
 	container := corev1.Container{
 		Name:  app.GetName(),
-		Image: app.GetImage(),
+		Image: ghcrify(app.GetImage()),
 		Ports: []corev1.ContainerPort{
 			{ContainerPort: int32(app.GetPort()), Protocol: corev1.ProtocolTCP, Name: nais_io_v1alpha1.DefaultPortName},
 		},
@@ -277,7 +277,7 @@ func CreateNaisjobContainer(naisjob *nais_io_v1.Naisjob, ast *resource.Ast, cfg 
 
 	container := corev1.Container{
 		Name:            naisjob.Name,
-		Image:           naisjob.Spec.Image,
+		Image:           ghcrify(naisjob.Spec.Image),
 		Command:         naisjob.Spec.Command,
 		Resources:       ResourceLimits(*naisjob.Spec.Resources),
 		ImagePullPolicy: corev1.PullIfNotPresent,
@@ -523,4 +523,8 @@ func allowed(capability string, allowedCapabilites []string) bool {
 		}
 	}
 	return false
+}
+
+func ghcrify(image string) string {
+	return strings.Replace(image, "docker.pkg.github.com", "ghcr.io", 1)
 }

--- a/pkg/resourcecreator/testdata/image_rewrite.yaml
+++ b/pkg/resourcecreator/testdata/image_rewrite.yaml
@@ -1,0 +1,28 @@
+testconfig:
+  description: images from registry docker.pkg.github.com is converted to ghcr.io format
+
+input:
+  kind: Application
+  apiVersion: nais.io/v1alpha1
+  metadata:
+    name: myapplication
+    namespace: mynamespace
+    labels:
+      team: myteam
+  spec:
+    image: docker.pkg.github.com/org/repo/name:version
+
+tests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: myapplication
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "image field is converted"
+        resource:
+          spec:
+            template:
+              spec:
+                containers:
+                  - image: ghcr.io/org/repo/name:version


### PR DESCRIPTION
As containerd container runtime does not support images from docker.pkg.github.com registry, we automatically convert old tags to new supported ghcr.io format