### PR TITLE
disable ginuudan for new naisjob deployments, enable hahaha

### DIFF
--- a/pkg/resourcecreator/pod/pod.go
+++ b/pkg/resourcecreator/pod/pod.go
@@ -357,11 +357,8 @@ func CreateNaisjobObjectMeta(naisjob *nais_io_v1.Naisjob, ast *resource.Ast, cfg
 
 	objectMeta.Annotations["kubectl.kubernetes.io/default-container"] = naisjob.GetName()
 
-	if naisjob.ObjectMeta.Annotations["nais.io/naisjob"] == "true" {
-		objectMeta.Labels["nais.io/naisjob"] = "true"
-	} else {
-		objectMeta.Annotations["ginuudan.nais.io/dwindle"] = "true"
-	}
+	// enables HAHAHA
+	objectMeta.Labels["nais.io/naisjob"] = "true"
 
 	if len(naisjob.Spec.Logformat) > 0 {
 		objectMeta.Annotations["nais.io/logformat"] = naisjob.Spec.Logformat

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_features_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_features_on_premises.yaml
@@ -84,11 +84,11 @@ tests:
                 template:
                   metadata:
                     annotations:
-                      ginuudan.nais.io/dwindle: "true"
                       kubectl.kubernetes.io/default-container: mynaisjob
                     labels:
                       app: mynaisjob
                       team: myteam
+                      nais.io/naisjob: "true"
                     name: mynaisjob
                     namespace: mynamespace
                     ownerReferences:

--- a/pkg/resourcecreator/testdata/naisjob/job_features_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/job_features_on_premises.yaml
@@ -83,11 +83,11 @@ tests:
             template:
               metadata:
                 annotations:
-                  ginuudan.nais.io/dwindle: "true"
                   kubectl.kubernetes.io/default-container: mynaisjob
                 labels:
                   app: mynaisjob
                   team: myteam
+                  nais.io/naisjob: "true"
                 name: mynaisjob
                 namespace: mynamespace
                 ownerReferences:

--- a/pkg/resourcecreator/testdata/naisjob/vanilla_cronjob_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/vanilla_cronjob_on_premises.yaml
@@ -82,11 +82,11 @@ tests:
                 template:
                   metadata:
                     annotations:
-                      ginuudan.nais.io/dwindle: "true"
                       kubectl.kubernetes.io/default-container: mynaisjob
                     labels:
                       app: mynaisjob
                       team: myteam
+                      nais.io/naisjob: "true"
                     name: mynaisjob
                     namespace: mynamespace
                     ownerReferences:

--- a/pkg/resourcecreator/testdata/naisjob/vanilla_job_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/vanilla_job_on_premises.yaml
@@ -79,11 +79,11 @@ tests:
             template:
               metadata:
                 annotations:
-                  ginuudan.nais.io/dwindle: "true"
                   kubectl.kubernetes.io/default-container: mynaisjob
                 labels:
                   app: mynaisjob
                   team: myteam
+                  nais.io/naisjob: "true"
                 name: mynaisjob
                 namespace: mynamespace
                 ownerReferences:


### PR DESCRIPTION
i just want to run this through here instead of pushing it straight to master. @ me on slack if you'd like to talk face to face about this stuff.

the short story about what's been done with hahaha the past few days:
* hahaha was deployed to every cluster on thursday or friday (can't remember exactly).
* team bømlo (namespace `tbd` in dev/prod-fss clusters) had issues on friday/monday where their namespace had gotten flooded by naisjobs that never reached completion. ginuudan simply hadn't done its job. no surprise there, tbh. i think it happens rather often.
* [a feature flag was added](https://github.com/nais/naiserator/pull/318/files#diff-16cc038e2ade22e27e055c59c9ffdf517fc834d72d4446bd7f5d38e2d74bec36L360-L361) in naiserator and bømlo could switch over to using hahaha as their janitor. this was kind of a trial by fire, but things have gone relatively smoothly.
* hahaha had some halting issues on portforward actions. it has been resolved with a one second timeout. if no response is received in that time, hahaha gives up and tries again on the next loop. it would previously wait indefinitely for a response.
  * i'm not sure if this retry logic works 100% as expected, but i *hope* it does. i'm thinking it could lead to some edge cases, but i've not had the chance to test it out. basically, i'm hoping that the pod shows up again for the watcher's next loop with a state change. the edge case i'm imagining is that if there's only one sidecar associated to the job which also requires portforward, if it fails then there might not be a state change on the next event watcher loop.
  * a simple redeploy/restart of hahaha resolves this, as it would see the job trying to turn off and try again with a portforward then. if the above edge cases occur eventually this can be a quick fix before reconsidering a business logic overhaul.
* prometheus and a [grafana board](https://grafana.nais.io/d/Xpc6VnI7z/sidecar-shutdowns-ginuudan-og-hahaha?from=now-24h&to=now&var-Interval=12h&var-interval=10m&orgId=1&refresh=30s) has been set up.
* a test naisjob has been running every 5 minutes the past ~24 hours in dev-gcp and no major issues have occurred. bømlo's jobs have also been running every 5 minutes in dev-fss with little warnings which were recoverable.
* on friday this week: the test naisjob has been deployed to every relevant cluster (dev-gcp, prod-gcp, dev-fss, and prod-fss), and there's an alert that fires if no naisjobs have been turned off in the past 15ish minutes.

i'm thinking we can just continue with the trial of fire here and enable hahaha for every new naisjob deployment.