### PR TITLE
feat: finalizer for opprydding i serviceaccount-namespace

### DIFF
--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -260,11 +260,16 @@ func (n *Synchronizer) Reconcile(ctx context.Context, req ctrl.Request, app reso
 // deleteCNRMResources removes the lingering IAMServiceAccounts and IAMPolicies in the serviceaccounts namespace
 func (n *Synchronizer) deleteCNRMResources(ctx context.Context, app resource.Source) error {
 	labelSelector := labels.NewSelector()
-	labelreq, err := labels.NewRequirement("app", selection.Equals, []string{app.GetName()})
+	appLabelreq, err := labels.NewRequirement("app", selection.Equals, []string{app.GetName()})
 	if err != nil {
 		return err
 	}
-	labelSelector = labelSelector.Add(*labelreq)
+	labelSelector = labelSelector.Add(*appLabelreq)
+	teamLabelreq, err := labels.NewRequirement("team", selection.Equals, []string{app.GetLabels()["team"]})
+	if err != nil {
+		return err
+	}
+	labelSelector = labelSelector.Add(*teamLabelreq)
 	listOpts := &client.ListOptions{
 		LabelSelector: labelSelector,
 		Namespace:     google.IAMServiceAccountNamespace,

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -7,18 +7,23 @@ import (
 	"sync"
 	"time"
 
+	iam_cnrm_cloud_google_com_v1beta1 "github.com/nais/liberator/pkg/apis/iam.cnrm.cloud.google.com/v1beta1"
 	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
 	generator2 "github.com/nais/naiserator/pkg/event/generator"
 	"github.com/nais/naiserator/pkg/readonly"
+	"github.com/nais/naiserator/pkg/resourcecreator/google"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/nais/naiserator/pkg/kafka"
 	"github.com/nais/naiserator/pkg/metrics"
@@ -29,9 +34,10 @@ import (
 
 const (
 	prepareRetryInterval = time.Minute * 30
+	NaiseratorFinalizer  = "naiserator.nais.io/finalizer"
 )
 
-// Generators transform CRD objects such as Application, Naisjob into other kinds of Kubernetes resources.
+// Generator transform CRD objects such as Application, Naisjob into other kinds of Kubernetes resources.
 // First, `Prepare()` is called. This function has access to (read-only) cluster operations and returns
 // a configuration object. Then, `Generate()` is called with the configuration object, and returns a full
 // set of Kubernetes resources.
@@ -129,17 +135,10 @@ func (n *Synchronizer) Reconcile(ctx context.Context, req ctrl.Request, app reso
 
 	err := n.Get(ctx, req.NamespacedName, app)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			logger := log.WithFields(log.Fields{
-				"namespace": req.Namespace,
-				"name":      req.Name,
-				"gvk":       app.GetObjectKind().GroupVersionKind().String(),
-			})
-			logger.Infof("Application has been deleted from Kubernetes")
-
-			err = nil
-		}
-		return ctrl.Result{}, err
+		// we'll ignore not-found errors, since they can't be fixed by an immediate
+		// requeue (we'll need to wait for a new notification), and we can get them
+		// on deleted requests.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	kind := app.GetObjectKind().GroupVersionKind().Kind
@@ -164,6 +163,38 @@ func (n *Synchronizer) Reconcile(ctx context.Context, req ctrl.Request, app reso
 			logger.Debugf("Application status: %+v'", app.GetStatus())
 		}
 	}()
+
+	if app.GetObjectMeta().GetDeletionTimestamp().IsZero() {
+		if !controllerutil.ContainsFinalizer(app, NaiseratorFinalizer) {
+			controllerutil.AddFinalizer(app, NaiseratorFinalizer)
+			err = n.Update(ctx, app)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else {
+		if controllerutil.ContainsFinalizer(app, NaiseratorFinalizer) {
+			err = n.deleteCNRMResources(ctx, app)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			controllerutil.RemoveFinalizer(app, NaiseratorFinalizer)
+			err = n.Update(ctx, app)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		logger := log.WithFields(log.Fields{
+			"namespace": req.Namespace,
+			"name":      req.Name,
+			"gvk":       app.GetObjectKind().GroupVersionKind().String(),
+		})
+		logger.Infof("Application has been deleted from Kubernetes")
+
+		return ctrl.Result{}, nil
+	}
 
 	rollout, err := n.Prepare(ctx, app)
 	if err != nil {
@@ -224,6 +255,51 @@ func (n *Synchronizer) Reconcile(ctx context.Context, req ctrl.Request, app reso
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// deleteCNRMResources removes the lingering IAMServiceAccounts and IAMPolicies in the serviceaccounts namespace
+func (n *Synchronizer) deleteCNRMResources(ctx context.Context, app resource.Source) error {
+	labelSelector := labels.NewSelector()
+	labelreq, err := labels.NewRequirement("app", selection.Equals, []string{app.GetName()})
+	if err != nil {
+		return err
+	}
+	labelSelector.Add(*labelreq)
+	listOpts := &client.ListOptions{
+		LabelSelector: labelSelector,
+		Namespace:     google.IAMServiceAccountNamespace,
+	}
+
+	IAMServiceAccountList := &iam_cnrm_cloud_google_com_v1beta1.IAMServiceAccountList{}
+	err = n.List(ctx, IAMServiceAccountList, listOpts)
+	if err != nil {
+		return err
+	}
+
+	logger := *log.WithFields(app.LogFields())
+	for _, item := range IAMServiceAccountList.Items {
+		logger.Infof("Deleting %v:%v in %v", item.GetObjectKind(), item.GetName(), item.GetNamespace())
+		// err = n.Delete(ctx, &item)
+		if err != nil {
+			return err
+		}
+	}
+
+	IAMPolicies := &iam_cnrm_cloud_google_com_v1beta1.IAMPolicyList{}
+	err = n.List(ctx, IAMPolicies, listOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range IAMPolicies.Items {
+		logger.Infof("Deleting %v:%v in %v", item.GetObjectKind(), item.GetName(), item.GetNamespace())
+		// err = n.Delete(ctx, &item)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Unreferenced return all resources in cluster which was created by synchronizer previously, but is not included in the current rollout.

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -276,10 +276,8 @@ func (n *Synchronizer) deleteCNRMResources(ctx context.Context, app resource.Sou
 		return err
 	}
 
-	logger := *log.WithFields(app.LogFields())
 	for _, item := range IAMServiceAccountList.Items {
-		logger.Infof("Deleting %v:%v in %v", item.GetObjectKind(), item.GetName(), item.GetNamespace())
-		// err = n.Delete(ctx, &item)
+		err = n.Delete(ctx, &item)
 		if err != nil {
 			return err
 		}
@@ -292,8 +290,7 @@ func (n *Synchronizer) deleteCNRMResources(ctx context.Context, app resource.Sou
 	}
 
 	for _, item := range IAMPolicies.Items {
-		logger.Infof("Deleting %v:%v in %v", item.GetObjectKind(), item.GetName(), item.GetNamespace())
-		// err = n.Delete(ctx, &item)
+		err = n.Delete(ctx, &item)
 		if err != nil {
 			return err
 		}

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -264,7 +264,7 @@ func (n *Synchronizer) deleteCNRMResources(ctx context.Context, app resource.Sou
 	if err != nil {
 		return err
 	}
-	labelSelector.Add(*labelreq)
+	labelSelector = labelSelector.Add(*labelreq)
 	listOpts := &client.ListOptions{
 		LabelSelector: labelSelector,
 		Namespace:     google.IAMServiceAccountNamespace,

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -283,8 +283,7 @@ func TestSynchronizer(t *testing.T) {
 	assert.Equal(t, "new-deploy-id", eventList.Items[0].Annotations[nais_io_v1.DeploymentCorrelationIDAnnotation])
 	assert.Equal(t, nais_io_v1.EventSynchronized, eventList.Items[0].Reason)
 
-	// Ensure that we delete correct IAM-resources from cnrm namespace
-	// Start by creating new app, which also will be the one we delete
+	// Assert that we delete the correct IAM-resources from the cnrm namespace
 	app2 := fixtures.MinimalApplication()
 	app2.SetAnnotations(map[string]string{
 		nais_io_v1.DeploymentCorrelationIDAnnotation: "deploy-id-2",
@@ -294,7 +293,6 @@ func TestSynchronizer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Application resource cannot be persisted to fake Kubernetes: %s", err)
 	}
-	// Reconcile the new app
 	req = ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: app2.Namespace,
@@ -305,7 +303,6 @@ func TestSynchronizer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 
-	// Ensure that we now have two IAMPolicy and two IAMServiceAccount
 	var iamPList iam_cnrm_cloud_google_com_v1beta1.IAMPolicyList
 	err = rig.client.List(ctx, &iamPList)
 	assert.NoError(t, err)
@@ -315,10 +312,8 @@ func TestSynchronizer(t *testing.T) {
 	err = rig.client.List(ctx, &iamSAlist)
 	assert.NoError(t, err)
 	assert.Len(t, iamSAlist.Items, 2)
-	// Ensure that one of the resources belongs to the last deployed app
 	assert.Equal(t, iamSAlist.Items[0].Labels["app"], app2.GetName())
 
-	// Delete the new app, and reconcile the app
 	rig.client.Delete(ctx, app2)
 	req = ctrl.Request{
 		NamespacedName: types.NamespacedName{
@@ -330,7 +325,6 @@ func TestSynchronizer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 
-	// Ensure that we are left with only on IAMPolicy and IAMServiceAccount
 	err = rig.client.List(ctx, &iamPList)
 	assert.NoError(t, err)
 	assert.Len(t, iamPList.Items, 1)
@@ -338,10 +332,7 @@ func TestSynchronizer(t *testing.T) {
 	err = rig.client.List(ctx, &iamSAlist)
 	assert.NoError(t, err)
 	assert.Len(t, iamSAlist.Items, 1)
-	// Ensure that the resource left belongs to the first app
 	assert.Equal(t, iamSAlist.Items[0].Labels["app"], app.GetName())
-
-	// We also test to see if
 }
 
 func TestSynchronizerResourceOptions(t *testing.T) {


### PR DESCRIPTION
Etter oppgradering til k8s v1.20 så kan ikke lengre ha ownerReference på tvers av namespaces. Derfor må vi ha et annet system for å kunne rydde opp i CNRM-namespacet vårt.

Her så legger vi på en finalizer som lar oss plukke opp når en nais-app blir slettet, og så slette alle tilhørende iampolicy og iamserviceaccounts i namespace serviceaccount.