### PR TITLE
fix: må ta vare på returverdien

### DIFF
--- a/updater/updater.go
+++ b/updater/updater.go
@@ -92,7 +92,7 @@ func FindAll(ctx context.Context, cli client.Client, scheme *runtime.Scheme, typ
 	if err != nil {
 		return nil, err
 	}
-	labelSelector.Add(*labelreq)
+	labelSelector = labelSelector.Add(*labelreq)
 	listopt := &client.ListOptions{
 		LabelSelector: labelSelector,
 	}


### PR DESCRIPTION
Dette betyr at FindAll-metoden aldri har fungert som ønskelig.