### PR TITLE
add public access prevention feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/magiconair/properties v1.8.5
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/mitchellh/mapstructure v1.4.2
-	github.com/nais/liberator v0.0.0-20220124151555-28e815a151b4
+	github.com/nais/liberator v0.0.0-20220316064829-bd3bfc332ea7
 	github.com/novln/docker-parser v0.0.0-20190306203532-b3f122c6978e
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nais/liberator v0.0.0-20220124151555-28e815a151b4 h1:vNwxrRdAuXx+SOjbYdGHSUU1gTsElKOakCsYeZkx/2o=
 github.com/nais/liberator v0.0.0-20220124151555-28e815a151b4/go.mod h1:AjfPx+WVWt8qKe1IFOSAAH5Im4qD5pMnxzw+SDn3rP8=
+github.com/nais/liberator v0.0.0-20220316064829-bd3bfc332ea7 h1:nTCERtdgXqLDPQ3ElwOMJ+xhJOwLDw0zcR3iC94+0tc=
+github.com/nais/liberator v0.0.0-20220316064829-bd3bfc332ea7/go.mod h1:AjfPx+WVWt8qKe1IFOSAAH5Im4qD5pMnxzw+SDn3rP8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/novln/docker-parser v0.0.0-20190306203532-b3f122c6978e h1:knbz2/KI77qbam+s2aLDSyUt4KdC8bE9XaeQUeTGfs8=
 github.com/novln/docker-parser v0.0.0-20190306203532-b3f122c6978e/go.mod h1:iDeGFp41QxV9wavwD8gqv5/Bhyh2pWJQb4TI3vhG7VQ=

--- a/pkg/resourcecreator/google/storagebucket/storagebucket.go
+++ b/pkg/resourcecreator/google/storagebucket/storagebucket.go
@@ -39,6 +39,7 @@ func CreateBucket(objectMeta metav1.ObjectMeta, bucket nais_io_v1.CloudStorageBu
 	storagebucketPolicySpec := google_storage_crd.StorageBucketSpec{
 		Location:                 google.Region,
 		UniformBucketLevelAccess: bucket.UniformBucketLevelAccess,
+		PublicAccessPrevention:   publicAccessPreventionAsString(bucket.PublicAccessPrevention),
 	}
 
 	if !bucket.CascadingDelete {
@@ -138,4 +139,11 @@ func Create(source Source, ast *resource.Ast, cfg Config, googleServiceAccount g
 	}
 
 	return nil
+}
+
+func publicAccessPreventionAsString(enforced bool) string {
+	if enforced {
+		return "enforced"
+	}
+	return "inherited"
 }

--- a/pkg/resourcecreator/google/storagebucket/storagebucket_test.go
+++ b/pkg/resourcecreator/google/storagebucket/storagebucket_test.go
@@ -62,7 +62,6 @@ func TestGetGoogleStorageBucket(t *testing.T) {
 			DeletionPolicyAnnotation])
 		assert.Nil(t, bucket.Spec.RetentionPolicy)
 	})
-
 }
 
 func intp(i int) *int {

--- a/pkg/resourcecreator/testdata/gcp_buckets_publicAccessPrevention.yaml
+++ b/pkg/resourcecreator/testdata/gcp_buckets_publicAccessPrevention.yaml
@@ -1,0 +1,148 @@
+testconfig:
+  description: google storage bucket with prevent access prevention
+
+config:
+  features:
+    access-policy: false
+    cnrm: true
+  google-project-id: google-project-id
+
+input:
+  kind: Application
+  apiVersion: nais.io/v1alpha1
+  metadata:
+    name: myapplication
+    namespace: mynamespace
+    uid: "123456"
+    labels:
+      team: myteam
+  spec:
+    image: navikt/myapplication:1.2.3
+    gcp:
+      buckets:
+        - name: myapplication
+          publicAccessPrevention: true
+
+existing:
+  - kind: Namespace
+    apiVersion: v1
+    metadata:
+      name: mynamespace
+      annotations:
+        cnrm.cloud.google.com/project-id: team-project-id
+
+tests:
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    operation: CreateIfNotExists
+    match:
+      - type: subset
+        name: "IAMServiceAccount created in namespace serviceaccounts"
+        exclude:
+          - .metadata.creationTimestamp
+        resource:
+          metadata:
+            annotations:
+              cnrm.cloud.google.com/project-id: google-project-id
+              nais.io/team: mynamespace
+            name: myapplicati-mynamespac-w4o5cwa
+            namespace: serviceaccounts
+          spec:
+            displayName: myapplication
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMPolicy
+    operation: CreateIfNotExists
+    match:
+      - type: subset
+        name: "IAMPolicy created in namespace serviceaccounts"
+        resource:
+          metadata:
+            annotations:
+              cnrm.cloud.google.com/project-id: google-project-id
+            name: myapplicati-mynamespac-w4o5cwa
+            namespace: serviceaccounts
+          spec:
+            bindings:
+              - members:
+                  - serviceAccount:google-project-id.svc.id.goog[mynamespace/myapplication]
+                role: roles/iam.workloadIdentityUser
+            resourceRef:
+              apiVersion: iam.cnrm.cloud.google.com/v1beta1
+              kind: IAMServiceAccount
+              name: myapplicati-mynamespac-w4o5cwa
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMPolicyMember
+    operation: CreateIfNotExists
+    match:
+      - type: subset
+        name: "IAMPolicyMember created in namespace mynamespace"
+        resource:
+          metadata:
+            annotations:
+              cnrm.cloud.google.com/project-id: team-project-id
+            name: myapplicati-mynamespac-w4o5cwa
+            namespace: mynamespace
+          spec:
+            member: serviceAccount:myapplicati-mynamespac-w4o5cwa@google-project-id.iam.gserviceaccount.com
+            role: roles/storage.objectViewer
+            resourceRef:
+              apiVersion: storage.cnrm.cloud.google.com/v1beta1
+              kind: StorageBucket
+              name: myapplication
+  - apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    kind: StorageBucket
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "Storage bucket created in team namespace"
+        resource:
+          metadata:
+            annotations:
+              cnrm.cloud.google.com/deletion-policy: abandon
+              cnrm.cloud.google.com/project-id: team-project-id
+              cnrm.cloud.google.com/state-into-spec: merge
+            name: myapplication
+            namespace: mynamespace
+          spec:
+            location: europe-north1
+            publicAccessPrevention: enforced
+  - apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    kind: StorageBucketAccessControl
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "Storage bucket ACL created in team namespace"
+        resource:
+          metadata:
+            name: myapplication
+            namespace: mynamespace
+          spec:
+            bucketRef:
+              name: myapplication
+            entity: user-myapplicati-mynamespac-w4o5cwa@google-project-id.iam.gserviceaccount.com
+            role: OWNER
+  - apiVersion: apps/v1
+    kind: Deployment
+    operation: CreateOrUpdate
+    name: myapplication
+    match:
+      - type: subset
+        name: "deployment created"
+        exclude:
+          - .metadata
+          - .status
+          - .spec.template.metadata
+        resource:
+          spec:
+            template:
+              spec:
+                containers:
+                  - image: navikt/myapplication:1.2.3
+                    env:
+                      - name: GCP_TEAM_PROJECT_ID
+                        value: team-project-id
+                dnsPolicy: ClusterFirst
+                imagePullSecrets:
+                  - name: gh-docker-credentials
+                restartPolicy: Always
+                serviceAccountName: myapplication


### PR DESCRIPTION
- Need to wait until [configconnector](https://cloud.google.com/config-connector/docs/release-notes#January_19_2022) >= 1.71 is installed in clusters for spec.publicAccessPrevention in StorageBucket resource.
- Need to merge liberator [PR](https://github.com/nais/liberator/pull/50) prior to this PR.

Co-authored-by: Kyrre Havik <kyrremann@gmail.com>