### PR TITLE
feat: sletter job ved endring

### DIFF
--- a/pkg/resourcecreator/batch/job.go
+++ b/pkg/resourcecreator/batch/job.go
@@ -60,6 +60,6 @@ func CreateJob(naisjob *nais_io_v1.Naisjob, ast *resource.Ast, cfg Config) error
 		Spec:       jobSpec,
 	}
 
-	ast.AppendOperation(resource.OperationCreateOrUpdate, &job)
+	ast.AppendOperation(resource.OperationCreateOrRecreate, &job)
 	return nil
 }

--- a/pkg/resourcecreator/testdata/naisjob/job_features_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/job_features_on_premises.yaml
@@ -49,7 +49,7 @@ tests:
         name: "service account created"
         resource: {}
 
-  - operation: CreateOrUpdate
+  - operation: CreateOrRecreate
     apiVersion: batch/v1
     kind: Job
     name: mynaisjob

--- a/pkg/resourcecreator/testdata/naisjob/vanilla_job_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/vanilla_job_on_premises.yaml
@@ -46,7 +46,7 @@ tests:
         name: "service account created"
         resource: {}
 
-  - operation: CreateOrUpdate
+  - operation: CreateOrRecreate
     apiVersion: batch/v1
     kind: Job
     name: mynaisjob

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -455,7 +455,7 @@ func (n *Synchronizer) ClusterOperations(ctx context.Context, rollout Rollout) [
 		case resource.OperationCreateOrUpdate:
 			c.fn = updater.CreateOrUpdate(ctx, n.Client, n.scheme, rop.Resource)
 		case resource.OperationCreateOrRecreate:
-			c.fn = updater.CreateOrRecreate(ctx, n.Client, rop.Resource)
+			c.fn = updater.CreateOrRecreate(ctx, n.Client, n.scheme, rop.Resource)
 		case resource.OperationCreateIfNotExists:
 			c.fn = updater.CreateIfNotExists(ctx, n.Client, rop.Resource)
 		case resource.OperationDeleteIfExists:

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"context"
 	"fmt"
+	"time"
 
 	sql_cnrm_cloud_google_com_v1beta1 "github.com/nais/liberator/pkg/apis/sql.cnrm.cloud.google.com/v1beta1"
 	storage_cnrm_cloud_google_com_v1beta1 "github.com/nais/liberator/pkg/apis/storage.cnrm.cloud.google.com/v1beta1"
@@ -51,13 +52,33 @@ func CreateOrUpdate(ctx context.Context, cli client.Client, scheme *runtime.Sche
 	}
 }
 
-func CreateOrRecreate(ctx context.Context, cli client.Client, resource client.Object) func() error {
+func CreateOrRecreate(ctx context.Context, cli client.Client, scheme *runtime.Scheme, resource client.Object) func() error {
 	return func() error {
 		log.Infof("CreateOrRecreate %s", liberator_scheme.TypeName(resource))
-		err := cli.Delete(ctx, resource)
+		deleteOptions := &client.DeleteOptions{}
+		client.PropagationPolicy(metav1.DeletePropagationBackground).ApplyToDelete(deleteOptions)
+		err := cli.Delete(ctx, resource, deleteOptions)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
+
+		existing, err := scheme.New(resource.GetObjectKind().GroupVersionKind())
+		if err != nil {
+			return fmt.Errorf("internal error: %w", err)
+		}
+		objectKey := client.ObjectKeyFromObject(resource)
+
+		for {
+			err = cli.Get(ctx, objectKey, existing.(client.Object))
+			if errors.IsNotFound(err) {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("internal error: %v", err)
+			}
+			time.Sleep(1 * time.Second)
+		}
+
 		return cli.Create(ctx, resource)
 	}
 }

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -67,6 +67,7 @@ func CreateOrRecreate(ctx context.Context, cli client.Client, scheme *runtime.Sc
 			return fmt.Errorf("internal error: %w", err)
 		}
 		objectKey := client.ObjectKeyFromObject(resource)
+		timedOut := time.Now().Add(time.Minute + time.Duration(5))
 
 		for {
 			err = cli.Get(ctx, objectKey, existing.(client.Object))
@@ -75,6 +76,9 @@ func CreateOrRecreate(ctx context.Context, cli client.Client, scheme *runtime.Sc
 			}
 			if err != nil {
 				return fmt.Errorf("internal error: %v", err)
+			}
+			if time.Now().After(timedOut) {
+				return fmt.Errorf("timed out waiting for deletion of %v/%v", resource.GetObjectKind(), resource.GetName())
 			}
 			time.Sleep(1 * time.Second)
 		}


### PR DESCRIPTION
For at sletting av en job skal fungere som ønsket trenger vi å være
sikker på at job-en er ryddet bort før vi lager den på nytt. Dette er
for å unngå race-condition. Vi må også bruke propagation policy for å
påse at pod-er tilknyttet en job også blir slettet.