### PR TITLE
Update dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Any unneeded resources will be automatically deleted if disabled by feature flag
 
 ## Documentation
 
-The entire specification for the manifest is documented in our [doc.nais.io](https://doc.nais.io/nais-application/).
+The entire specification for the manifest is documented in our [doc.nais.io](https://doc.nais.io/nais-application/application/).
 
 ## Deployment
 


### PR DESCRIPTION
The README currently includes a dead link to the nais docs page. Expected behaviour would be for it to lead to the nais Application reference page. This PR fixes that dead link.

![bilde](https://user-images.githubusercontent.com/5845924/166989845-8e3a5d02-d68b-4a8f-ab0c-6e685f5e36cb.png)
