### PR TITLE
fix(networkpolicy): do not add ingress/egress rules for empty list of peers

### DIFF
--- a/pkg/resourcecreator/testdata/accesspolicy_only_other_clusters.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_only_other_clusters.yaml
@@ -1,0 +1,87 @@
+testconfig:
+  description: accesspolicy containing rules for only other clusters should not add empty ingress and egress rules
+
+config:
+  features:
+    linkerd: true
+    network-policy: true
+  google-project-id: google-project-id
+  cluster-name: mycluster
+
+input:
+  kind: Application
+  apiVersion: nais.io/v1alpha1
+  metadata:
+    name: myapplication
+    namespace: mynamespace
+    labels:
+      team: myteam
+  spec:
+    image: foo/bar
+    accessPolicy:
+      inbound:
+        rules:
+          - application: bar
+            namespace: baz
+            cluster: othercluster
+      outbound:
+        rules:
+          - application: foo
+            namespace: bar
+            cluster: othercluster
+
+tests:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    name: myapplication
+    operation: CreateOrUpdate
+    match:
+      - type: exact
+        name: "egress and ingress network policies"
+        exclude:
+          - .metadata
+        resource:
+          spec:
+            ingress:
+              - from:
+                - podSelector:
+                    matchLabels:
+                      app: prometheus
+                  namespaceSelector:
+                    matchLabels:
+                      name: nais
+              - from:
+                - namespaceSelector:
+                    matchLabels:
+                      linkerd.io/is-control-plane: "true"
+              - from:
+                - namespaceSelector:
+                    matchLabels:
+                      linkerd.io/extension: viz
+                  podSelector:
+                    matchLabels:
+                      component: tap
+              - from:
+                - namespaceSelector:
+                    matchLabels:
+                      linkerd.io/extension: viz
+                  podSelector:
+                    matchLabels:
+                      component: prometheus
+            egress:
+              - to:
+                - namespaceSelector:
+                    matchLabels:
+                      linkerd.io/is-control-plane: "true"
+                - podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+                  namespaceSelector: { }
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+            policyTypes:
+              - Ingress
+              - Egress
+            podSelector:
+              matchLabels:
+                app: myapplication


### PR DESCRIPTION
Previously, an app could define an access policy as follows:

```yaml
spec:
  ...
  accessPolicy:
    inbound:
      rules:
        - application: bar
          namespace: baz
          cluster: othercluster
    outbound:
      rules:
        - application: foo
          namespace: bar
          cluster: othercluster
```

As network policies aren't applicable for other clusters, the resulting `[]networkingv1.NetworkPolicyPeer` returned from https://github.com/nais/naiserator/blob/f9c7fbb863048e9d0a3b00bd9345cace7e6132c5/pkg/resourcecreator/networkpolicy/networkpolicy.go#L95-L119 would be empty for the above example. The peers were added to both an ingress and egress rule, which results in a `NetworkPolicy` that contains empty rules:

```yaml
spec:
  ingress:
    ...
    - {}
  egress:
    ...
    - {}
```

...which effectively allows all traffic as noted by the `from` and `to` fields for both `NetworkPolicyIngressRule` and `NetworkPolicyEgressRule`:

> If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination).

This pull request fixes this by only adding the ingress/egress rules if the peers are non-empty.