### PR TITLE
add: secomp profile with Runtime default for pod and container

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -78,6 +78,8 @@ podSecurityContext:
   runAsNonRoot: true
   supplementalGroups:
     - 65532
+  seccompProfile:
+    type: RuntimeDefault
 
   # fsGroup: 2000
 
@@ -88,3 +90,5 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 65532
+  seccompProfile:
+    type: RuntimeDefault

--- a/pkg/resourcecreator/leaderelection/leaderelection.go
+++ b/pkg/resourcecreator/leaderelection/leaderelection.go
@@ -10,6 +10,7 @@ import (
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/pointer"
 )
 
 type ElectionMode int
@@ -168,6 +169,20 @@ func container(name, namespace, image string) corev1.Container {
 			{
 				Name:  "ELECTOR_LOG_FORMAT",
 				Value: "json",
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                pointer.Int64(1069),
+			RunAsGroup:               pointer.Int64(1069),
+			RunAsNonRoot:             pointer.Bool(true),
+			Privileged:               pointer.Bool(false),
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			ReadOnlyRootFilesystem:   pointer.Bool(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		},
 	}

--- a/pkg/resourcecreator/pod/pod.go
+++ b/pkg/resourcecreator/pod/pod.go
@@ -113,10 +113,19 @@ func CreateSpec(ast *resource.Ast, cfg Config, appName string, annotations map[s
 			Privileged:               pointer.BoolPtr(false),
 			AllowPrivilegeEscalation: pointer.BoolPtr(false),
 			ReadOnlyRootFilesystem:   pointer.BoolPtr(readOnlyFileSystem(annotations)),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+
+		podSpec.SecurityContext = &corev1.PodSecurityContext{
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		}
 
 		capabilities := &corev1.Capabilities{
-			Drop: []corev1.Capability{"all"},
+			Drop: []corev1.Capability{"ALL"},
 		}
 
 		additionalCapabilities := sanitizeCapabilities(annotations, cfg.GetAllowedKernelCapabilities())

--- a/pkg/resourcecreator/testdata/additional_kernel_capabilities.yaml
+++ b/pkg/resourcecreator/testdata/additional_kernel_capabilities.yaml
@@ -42,7 +42,9 @@ tests:
                       allowPrivilegeEscalation: false
                       runAsNonRoot: true
                       privileged: false
+                      seccompProfile:
+                        type: RuntimeDefault
                       capabilities:
-                        drop: ["all"]
+                        drop: ["ALL"]
                         add: ["NET_RAW", "NET_BIND_SERVICE"]
 

--- a/pkg/resourcecreator/testdata/azureadapplication_wonderwall_minimal.yaml
+++ b/pkg/resourcecreator/testdata/azureadapplication_wonderwall_minimal.yaml
@@ -83,7 +83,9 @@ tests:
                       allowPrivilegeEscalation: false
                       capabilities:
                         drop:
-                          - all
+                          - ALL
+                      seccompProfile:
+                        type: RuntimeDefault
                       privileged: false
                       readOnlyRootFilesystem: true
                       runAsGroup: 1069

--- a/pkg/resourcecreator/testdata/idporten_wonderwall_minimal.yaml
+++ b/pkg/resourcecreator/testdata/idporten_wonderwall_minimal.yaml
@@ -128,7 +128,9 @@ tests:
                       allowPrivilegeEscalation: false
                       capabilities:
                         drop:
-                          - all
+                          - ALL
+                      seccompProfile:
+                        type: RuntimeDefault
                       privileged: false
                       readOnlyRootFilesystem: true
                       runAsGroup: 1069

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_features_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_features_on_premises.yaml
@@ -97,6 +97,9 @@ tests:
                         name: mynaisjob
                         uid: "123456"
                   spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
                     containers:
                       - env:
                           - name: NAV_TRUSTSTORE_PATH
@@ -125,8 +128,10 @@ tests:
                           runAsNonRoot: true
                           readOnlyRootFilesystem: true
                           privileged: false
+                          seccompProfile:
+                            type: RuntimeDefault
                           capabilities:
-                            drop: ["all"]
+                            drop: ["ALL"]
                         imagePullPolicy: IfNotPresent
                         lifecycle:
                           preStop:

--- a/pkg/resourcecreator/testdata/naisjob/job_features_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/job_features_on_premises.yaml
@@ -96,6 +96,9 @@ tests:
                     name: mynaisjob
                     uid: "123456"
               spec:
+                securityContext:
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - env:
                       - name: NAV_TRUSTSTORE_PATH
@@ -124,8 +127,10 @@ tests:
                       readOnlyRootFilesystem: true
                       runAsNonRoot: true
                       privileged: false
+                      seccompProfile:
+                        type: RuntimeDefault
                       capabilities:
-                        drop: ["all"]
+                        drop: ["ALL"]
                     imagePullPolicy: IfNotPresent
                     lifecycle:
                       preStop:

--- a/pkg/resourcecreator/testdata/naisjob/vanilla_cronjob_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/vanilla_cronjob_on_premises.yaml
@@ -95,6 +95,9 @@ tests:
                         name: mynaisjob
                         uid: "123456"
                   spec:
+                    securityContext:
+                      seccompProfile:
+                        type: RuntimeDefault
                     containers:
                       - env:
                           - name: NAV_TRUSTSTORE_PATH
@@ -123,8 +126,10 @@ tests:
                           runAsNonRoot: true
                           readOnlyRootFilesystem: true
                           privileged: false
+                          seccompProfile:
+                            type: RuntimeDefault
                           capabilities:
-                            drop: ["all"]
+                            drop: ["ALL"]
                         imagePullPolicy: IfNotPresent
                         lifecycle:
                           preStop:

--- a/pkg/resourcecreator/testdata/naisjob/vanilla_job_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/vanilla_job_on_premises.yaml
@@ -92,6 +92,9 @@ tests:
                     name: mynaisjob
                     uid: "123456"
               spec:
+                securityContext:
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - env:
                       - name: NAV_TRUSTSTORE_PATH
@@ -120,8 +123,10 @@ tests:
                       runAsNonRoot: true
                       readOnlyRootFilesystem: true
                       privileged: false
+                      seccompProfile:
+                        type: RuntimeDefault
                       capabilities:
-                        drop: ["all"]
+                        drop: ["ALL"]
                     imagePullPolicy: IfNotPresent
                     lifecycle:
                       preStop:

--- a/pkg/resourcecreator/testdata/vanilla_gcp.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_gcp.yaml
@@ -215,6 +215,9 @@ tests:
           spec:
             template:
               spec:
+                securityContext:
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - securityContext:
                       runAsUser: 1069
@@ -222,5 +225,7 @@ tests:
                       allowPrivilegeEscalation: false
                       runAsNonRoot: true
                       privileged: false
+                      seccompProfile:
+                        type: RuntimeDefault
                       capabilities:
-                        drop: ["all"]
+                        drop: ["ALL"]

--- a/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
@@ -124,6 +124,9 @@ tests:
                   team: myteam
                   app: myapplication
               spec:
+                securityContext:
+                  seccompProfile:
+                    type: RuntimeDefault
                 volumes:
                   - name: ca-bundle-jks
                     configMap:
@@ -145,8 +148,10 @@ tests:
                       readOnlyRootFilesystem: true
                       runAsNonRoot: true
                       privileged: false
+                      seccompProfile:
+                        type: RuntimeDefault
                       capabilities:
-                        drop: ["all"]
+                        drop: ["ALL"]
                     env:
                       - name: NAV_TRUSTSTORE_PATH
                         value: /etc/ssl/certs/java/cacerts

--- a/pkg/resourcecreator/wonderwall/wonderwall.go
+++ b/pkg/resourcecreator/wonderwall/wonderwall.go
@@ -153,13 +153,16 @@ func sidecarContainer(source Source, config Config, cfg Configuration) (*corev1.
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: pointer.Bool(false),
 			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"all"},
+				Drop: []corev1.Capability{"ALL"},
 			},
 			Privileged:             pointer.Bool(false),
 			ReadOnlyRootFilesystem: pointer.Bool(true),
 			RunAsGroup:             pointer.Int64(1069),
 			RunAsNonRoot:           pointer.Bool(true),
 			RunAsUser:              pointer.Int64(1069),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
updated capabilities to use the right value for drop "ALL". update tests accordingly.

Co-authored-by: Frode Sundby <frode.sundby@nav.no>
Co-authored-by: Thomas Siegfried Krampl <thomas.siegfried.krampl@nav.no>