### PR TITLE
chart: Add networkpolicy for apiserver access

### DIFF
--- a/charts/templates/netpol.yaml
+++ b/charts/templates/netpol.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-apiserver
+spec:
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ index .Values.naiserator "api-server-ip" }}/32
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+      from: []
+  podSelector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+    - Ingress


### PR DESCRIPTION
After
https://github.com/nais/aivenator/commit/89904b94fb36add63966e2e2710189a1efea5e82, naiserator is unable to access the apiserver because it has the `kafka=enabled` label.
This commit adds a netpol using the existing value for allowing apiserver access.