### PR TITLE
add network policies for legacy cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.25.4
-	k8s.io/apimachinery v0.25.4
+	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.25.4
 	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2
 	//sigs.k8s.io/controller-runtime v0.13.1

--- a/go.sum
+++ b/go.sum
@@ -450,14 +450,14 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo/v2 v2.1.6 h1:Fx2POJZfKRQcM1pH49qSZiYeu319wji004qX+GDovrU=
+github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
-github.com/onsi/gomega v1.20.1 h1:PA/3qinGoukvymdIDV8pii6tiZgC8kbmJO6Z5+b002Q=
+github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
@@ -1025,8 +1025,8 @@ k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdB
 k8s.io/apiextensions-apiserver v0.25.4 h1:7hu9pF+xikxQuQZ7/30z/qxIPZc2J1lFElPtr7f+B6U=
 k8s.io/apiextensions-apiserver v0.25.4/go.mod h1:bkSGki5YBoZWdn5pWtNIdGvDrrsRWlmnvl9a+tAw5vQ=
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
-k8s.io/apimachinery v0.25.4 h1:CtXsuaitMESSu339tfhVXhQrPET+EiWnIY1rcurKnAc=
-k8s.io/apimachinery v0.25.4/go.mod h1:jaF9C/iPNM1FuLl7Zuy5b9v+n35HGSh6AQ4HYRkCqwo=
+k8s.io/apimachinery v0.26.1 h1:8EZ/eGJL+hY/MYCNwhmDzVqq2lPl3N3Bo8rvweJwXUQ=
+k8s.io/apimachinery v0.26.1/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
 k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/client-go v0.17.2/go.mod h1:QAzRgsa0C2xl4/eVpeVAZMvikCn8Nm81yqVx3Kk9XYI=
 k8s.io/client-go v0.25.4 h1:3RNRDffAkNU56M/a7gUfXaEzdhZlYhoW8dgViGy5fn8=

--- a/pkg/resourcecreator/networkpolicy/networkpolicy.go
+++ b/pkg/resourcecreator/networkpolicy/networkpolicy.go
@@ -177,9 +177,15 @@ func ingressRulesFromIngress(ingress []nais_io_v1.Ingress, cfg Config) []network
 
 			// TODO: remove when loadbalancer features are installed in nais-system for legacy gcp
 			if cfg.IsLegacyGCP() {
-				ns = "nginx"
 				// assumes that ingressClass equals instance name label
-				ls = labelSelector("app.kubernetes.io/instance", *ingressClass)
+				rules = append(rules, networkingv1.NetworkPolicyIngressRule{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: labelSelector("name", "nginx"),
+							PodSelector:       labelSelector("app.kubernetes.io/instance", *ingressClass),
+						},
+					},
+				})
 			}
 
 			rules = append(rules, networkingv1.NetworkPolicyIngressRule{
@@ -216,6 +222,14 @@ func legacyNetpolSpec(appName string) networkingv1.NetworkPolicySpec {
 			networkingv1.PolicyTypeEgress,
 		},
 		Ingress: []networkingv1.NetworkPolicyIngressRule{
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: labelSelector("name", "nais"),
+						PodSelector:       labelSelector("app.kubernetes.io/name", "prometheus"),
+					},
+				},
+			},
 			{
 				From: []networkingv1.NetworkPolicyPeer{
 					{

--- a/pkg/resourcecreator/testdata/accesspolicy_legacy_gcp.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_legacy_gcp.yaml
@@ -14,7 +14,7 @@ config:
       ingressClass: adeo-gateway
     - domainSuffix: .domain
       ingressClass: domain-gateway
-  nais-namespace: nais
+  nais-namespace: nais-system
 
 
 input:
@@ -68,6 +68,13 @@ tests:
               - from:
                   - namespaceSelector:
                       matchLabels:
+                        name: "nais"
+                    podSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: prometheus
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
                         linkerd.io/is-control-plane: "true"
             egress:
               - to:
@@ -107,7 +114,7 @@ tests:
                         app.kubernetes.io/name: prometheus
                     namespaceSelector:
                       matchLabels:
-                        name: nais
+                        name: nais-system
               - from:
                   - namespaceSelector:
                       matchLabels:
@@ -118,10 +125,24 @@ tests:
               - from:
                   - namespaceSelector:
                       matchLabels:
+                        name: nais-system
+                    podSelector:
+                      matchLabels:
+                        nais.io/ingressClass: adeo-gateway
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
                         name: nginx
                     podSelector:
                       matchLabels:
                         app.kubernetes.io/instance: domain-gateway
+              - from:
+                  - namespaceSelector:
+                      matchLabels:
+                        name: nais-system
+                    podSelector:
+                      matchLabels:
+                        nais.io/ingressClass: domain-gateway
               - from:
                   - podSelector:
                       matchLabels:

--- a/pkg/resourcecreator/testdata/vanilla_legacy_gcp.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_legacy_gcp.yaml
@@ -6,7 +6,7 @@ config:
     linkerd: true
     network-policy: true
     legacy-gcp: true
-  nais-namespace: nais
+  nais-namespace: nais-system
   google-project-id: google-project-id
 
 input:
@@ -106,6 +106,13 @@ tests:
                         - 192.168.0.0/16
             ingress:
               - from:
+                    - namespaceSelector:
+                        matchLabels:
+                          name: "nais"
+                      podSelector:
+                        matchLabels:
+                          app.kubernetes.io/name: prometheus
+              - from:
                   - namespaceSelector:
                       matchLabels:
                         linkerd.io/is-control-plane: "true"
@@ -138,7 +145,7 @@ tests:
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nais
+                        name: nais-system
                     podSelector:
                       matchLabels:
                         app.kubernetes.io/name: prometheus


### PR DESCRIPTION
* add prometheus network policy rule for legacy instead of overwriting
* add ingress network policy for both new and old loadbalancers

Co-authored-by: Thomas Krampl <thomas.siegfried.krampl@nav.no>
Co-authored-by: rbjornstad <roger.bjornstad@nav.no>
Co-authored-by: Terje Sannum <terje.sannum@nav.no>
