### PR TITLE
networkpolicy: support wildcard namespaces for inbound traffic

### DIFF
--- a/pkg/resourcecreator/networkpolicy/networkpolicy.go
+++ b/pkg/resourcecreator/networkpolicy/networkpolicy.go
@@ -294,7 +294,9 @@ func ingressRulesFromAccessPolicy(policy *nais_io_v1.AccessPolicy, options Confi
 			peer.PodSelector = labelSelector("app", rule.Application)
 		}
 
-		if rule.Namespace != "" {
+		if rule.Namespace == "*" {
+			peer.NamespaceSelector = &metav1.LabelSelector{}
+		} else if rule.Namespace != "" {
 			peer.NamespaceSelector = labelSelector("name", rule.Namespace)
 		}
 

--- a/pkg/resourcecreator/testdata/accesspolicy_ingress_allow_all.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_ingress_allow_all.yaml
@@ -1,0 +1,62 @@
+testconfig:
+  description: network policy that allows ingress traffic for all pods in all namespaces
+
+config:
+  features:
+    network-policy: true
+  cluster-name: mycluster
+  nais-namespace: nais-system
+
+input:
+  kind: Application
+  apiVersion: nais.io/v1alpha1
+  metadata:
+    name: myapplication
+    namespace: mynamespace
+    uid: "123456"
+    labels:
+      team: myteam
+  spec:
+    image: navikt/myapplication:1.2.3
+    accessPolicy:
+      inbound:
+        rules:
+          - application: '*'
+            namespace: '*'
+
+tests:
+  - operation: CreateOrUpdate
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    name: myapplication
+    match:
+      - name: "network policy created"
+        type: exact
+        exclude:
+          - .metadata
+          - .status
+        resource:
+          spec:
+            egress:
+              - to:
+                  - namespaceSelector: {}
+                    podSelector:
+                      matchLabels:
+                        k8s-app: kube-dns
+            ingress:
+              - from:
+                  - podSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: prometheus
+                    namespaceSelector:
+                      matchLabels:
+                        name: nais-system
+              - from:
+                  - namespaceSelector: {}
+                    podSelector: {}
+            policyTypes:
+              - Ingress
+              - Egress
+            podSelector:
+              matchLabels:
+                app: myapplication


### PR DESCRIPTION
Some teams have applications that they want to allow inbound traffic to from various pods within the cluster - without having to manually manage an ever-growing list of applications.

This PR adds wildcard support to namespaces so that our users don't have to create and maintain their own NetworkPolicy for this use case.