### PR TITLE
Make generateNameFromMountPath work for paths with special chars in them

### DIFF
--- a/pkg/resourcecreator/pod/pod.go
+++ b/pkg/resourcecreator/pod/pod.go
@@ -208,11 +208,14 @@ func fromEnvConfigmap(name string) corev1.EnvFromSource {
 	}
 }
 
-var regNameNormalizer = regexp.MustCompile("[^a-zA-Z0-9_-]+")
+// A lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
+// and must start and end with an alphanumeric character
+var regNameNormalizer = regexp.MustCompile("[^a-z0-9-]+")
 
 func generateNameFromMountPath(mountPath string) string {
-	s := regNameNormalizer.ReplaceAllString(mountPath, "-")
-	s = strings.Trim(s, "-_")
+	s := strings.ToLower(mountPath)
+	s = regNameNormalizer.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
 	return s
 }
 

--- a/pkg/resourcecreator/pod/pod.go
+++ b/pkg/resourcecreator/pod/pod.go
@@ -2,6 +2,7 @@ package pod
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -208,8 +209,13 @@ func fromEnvConfigmap(name string) corev1.EnvFromSource {
 }
 
 func generateNameFromMountPath(mountPath string) string {
-	s := strings.Trim(mountPath, "/")
-	return strings.ReplaceAll(s, "/", "-")
+	reg, err := regexp.Compile("[^a-zA-Z0-9_-]+")
+	if err != nil {
+		log.Fatal(err)
+	}
+	s := reg.ReplaceAllString(mountPath, "-")
+	s = strings.Trim(s, "-_")
+	return s
 }
 
 func filesFrom(ast *resource.Ast, naisFilesFrom []nais_io_v1.FilesFrom) {

--- a/pkg/resourcecreator/pod/pod.go
+++ b/pkg/resourcecreator/pod/pod.go
@@ -208,12 +208,10 @@ func fromEnvConfigmap(name string) corev1.EnvFromSource {
 	}
 }
 
+var regNameNormalizer = regexp.MustCompile("[^a-zA-Z0-9_-]+")
+
 func generateNameFromMountPath(mountPath string) string {
-	reg, err := regexp.Compile("[^a-zA-Z0-9_-]+")
-	if err != nil {
-		log.Fatal(err)
-	}
-	s := reg.ReplaceAllString(mountPath, "-")
+	s := regNameNormalizer.ReplaceAllString(mountPath, "-")
 	s = strings.Trim(s, "-_")
 	return s
 }

--- a/pkg/resourcecreator/pod/pod_test.go
+++ b/pkg/resourcecreator/pod/pod_test.go
@@ -3,28 +3,21 @@ package pod
 import "testing"
 
 func TestGenerateNameFromMountPath(t *testing.T) {
-	t.Run("should generate name for normal mount path", func(t *testing.T) {
-		mountPath := "/var/run/my-config_maps"
-		name := generateNameFromMountPath(mountPath)
-		if name != "var-run-my-config-maps" {
-			t.Errorf("expected name to be 'var-run-my-config-maps', was '%s'", name)
-		}
-	})
+	testCases := []struct {
+		mountPath string
+		expected  string
+	}{
+		{"/var/run/my-config_maps", "var-run-my-config-maps"},
+		{"/var/run/secrets/nais.io/vault", "var-run-secrets-nais-io-vault"},
+		{".var/run/my-config_maps_", "var-run-my-config-maps"},
+	}
 
-	t.Run("should generate name from mount path containing dot", func(t *testing.T) {
-		mountPath := "/var/run/secrets/nais.io/vault"
-		name := generateNameFromMountPath(mountPath)
-		if name != "var-run-secrets-nais-io-vault" {
-			t.Errorf("expected name to be 'var-run-secrets-nais-io-vault', was '%s'", name)
-		}
-	})
-
-	t.Run("should remove trailing and leading special chars", func(t *testing.T) {
-		mountPath := ".var/run/my-config_maps_"
-		name := generateNameFromMountPath(mountPath)
-		if name != "var-run-my-config-maps" {
-			t.Errorf("expected name to be 'var-run-my-config-maps', was '%s'", name)
-		}
-	})
-
+	for _, tc := range testCases {
+		t.Run(tc.mountPath, func(t *testing.T) {
+			name := generateNameFromMountPath(tc.mountPath)
+			if name != tc.expected {
+				t.Errorf("expected name to be '%s', was '%s'", tc.expected, name)
+			}
+		})
+	}
 }

--- a/pkg/resourcecreator/pod/pod_test.go
+++ b/pkg/resourcecreator/pod/pod_test.go
@@ -6,8 +6,8 @@ func TestGenerateNameFromMountPath(t *testing.T) {
 	t.Run("should generate name for normal mount path", func(t *testing.T) {
 		mountPath := "/var/run/my-config_maps"
 		name := generateNameFromMountPath(mountPath)
-		if name != "var-run-my-config_maps" {
-			t.Errorf("expected name to be 'var-run-my-config_maps', was '%s'", name)
+		if name != "var-run-my-config-maps" {
+			t.Errorf("expected name to be 'var-run-my-config-maps', was '%s'", name)
 		}
 	})
 
@@ -22,8 +22,8 @@ func TestGenerateNameFromMountPath(t *testing.T) {
 	t.Run("should remove trailing and leading special chars", func(t *testing.T) {
 		mountPath := ".var/run/my-config_maps_"
 		name := generateNameFromMountPath(mountPath)
-		if name != "var-run-my-config_maps" {
-			t.Errorf("expected name to be 'var-run-my-config_maps', was '%s'", name)
+		if name != "var-run-my-config-maps" {
+			t.Errorf("expected name to be 'var-run-my-config-maps', was '%s'", name)
 		}
 	})
 

--- a/pkg/resourcecreator/pod/pod_test.go
+++ b/pkg/resourcecreator/pod/pod_test.go
@@ -7,7 +7,7 @@ func TestGenerateNameFromMountPath(t *testing.T) {
 		mountPath := "/var/run/my-config_maps"
 		name := generateNameFromMountPath(mountPath)
 		if name != "var-run-my-config_maps" {
-			t.Errorf("expected name to be 'var-run-configmaps', was '%s'", name)
+			t.Errorf("expected name to be 'var-run-my-config_maps', was '%s'", name)
 		}
 	})
 
@@ -23,7 +23,7 @@ func TestGenerateNameFromMountPath(t *testing.T) {
 		mountPath := ".var/run/my-config_maps_"
 		name := generateNameFromMountPath(mountPath)
 		if name != "var-run-my-config_maps" {
-			t.Errorf("expected name to be 'var-run-configmaps', was '%s'", name)
+			t.Errorf("expected name to be 'var-run-my-config_maps', was '%s'", name)
 		}
 	})
 

--- a/pkg/resourcecreator/pod/pod_test.go
+++ b/pkg/resourcecreator/pod/pod_test.go
@@ -1,0 +1,30 @@
+package pod
+
+import "testing"
+
+func TestGenerateNameFromMountPath(t *testing.T) {
+	t.Run("should generate name for normal mount path", func(t *testing.T) {
+		mountPath := "/var/run/my-config_maps"
+		name := generateNameFromMountPath(mountPath)
+		if name != "var-run-my-config_maps" {
+			t.Errorf("expected name to be 'var-run-configmaps', was '%s'", name)
+		}
+	})
+
+	t.Run("should generate name from mount path containing dot", func(t *testing.T) {
+		mountPath := "/var/run/secrets/nais.io/vault"
+		name := generateNameFromMountPath(mountPath)
+		if name != "var-run-secrets-nais-io-vault" {
+			t.Errorf("expected name to be 'var-run-secrets-nais-io-vault', was '%s'", name)
+		}
+	})
+
+	t.Run("should remove trailing and leading special chars", func(t *testing.T) {
+		mountPath := ".var/run/my-config_maps_"
+		name := generateNameFromMountPath(mountPath)
+		if name != "var-run-my-config_maps" {
+			t.Errorf("expected name to be 'var-run-configmaps', was '%s'", name)
+		}
+	})
+
+}


### PR DESCRIPTION
Currently the following application spec does not work:

```yaml
 filesFrom:
    - emptyDir:
        medium: Memory
      mountPath: /app/.next/cache
```

It results in the following error:

```
Error: Status: failure: Application/swag-shop (FailedSynchronization): persisting Deployment to Kubernetes: Invalid: Deployment.apps "swag-shop" is invalid: [spec.template.spec.volumes[2].name: Invalid value: "app-.next-cache": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.template.spec.containers[0].volumeMounts[6].name: Not found: "app-.next-cache"] (total of 1 errors)
```

This pull requests replaces everything that is not `A-Za-z0-9-_` with `-` and prevents there from being non alpha numeric chars at the start and end of the resulting name.