### PR TITLE
feat: bump CloudSqlProxy til v1.33.9

### DIFF
--- a/charts/naiserator/values.yaml
+++ b/charts/naiserator/values.yaml
@@ -19,7 +19,7 @@ naiserator:
   bind: 0.0.0.0:8080
   cluster-name: ""
   google-project-id: ""
-  google-cloud-sql-proxy-container-image: "gcr.io/cloudsql-docker/gce-proxy:1.24.0-alpine"
+  google-cloud-sql-proxy-container-image: "gcr.io/cloudsql-docker/gce-proxy:1.33.9-alpine"
   api-server-ip: ""
   host-aliases: ""
   nais-namespace: "nais-system"


### PR DESCRIPTION
Hovedsakelig oppgradert avhengigheter, og Go til v1.20. Ellers er det disse endringene:
- require login_token with token and enable_iam_login (#1641) (48a2fe5)
- deprecate proxy drivers (#1500) (2b460ea)
- Downscope OAuth2 token included in ephemeral certificate (#1450) (7557a35)
- add support for ReadTime in Admin API requests (#1040) (a7c8b5c)
- add support for specifying a quota project (#1044) (dc66aca)
- allow multiple -instances flags (#1046) (1972693), closes #1030
- add health checks to proxy (#859) (ea62bdd)
- add instance dialing to health check (#871) (eca3793)
- require TLS v1.3 at minimum (#906) (cafa966)