### PR TITLE
feat(controllers): allow configuration of max concurrent reconciles

### DIFF
--- a/charts/naiserator/values.yaml
+++ b/charts/naiserator/values.yaml
@@ -58,6 +58,9 @@ naiserator:
   proxy:
     address: http://webproxy.nais:8088
     exclude: localhost,127.0.0.1,10.254.0.1,.local,.adeo.no,.nav.no,.aetat.no,.devillo.no,.oera.no,.nais.io,.aivencloud.com,.intern.dev.nav.no
+  ratelimit:
+    qps: 20
+    burst: 200
   securelogs:
     configmap-reload-image: ghcr.io/nais/configmap-reload/configmap-reload@sha256:3f30687b1200754924484a12124f7be58a55816661d864f6d1bf44e1131b6de6
     fluentd-image: europe-north1-docker.pkg.dev/nais-io/nais/images/nais-logd:107

--- a/charts/naiserator/values.yaml
+++ b/charts/naiserator/values.yaml
@@ -54,6 +54,7 @@ naiserator:
       enabled: true
       insecure: false
     topic: aura.dev-rapid
+  max-concurrent-reconciles: 1
   proxy:
     address: http://webproxy.nais:8088
     exclude: localhost,127.0.0.1,10.254.0.1,.local,.adeo.no,.nav.no,.aetat.no,.devillo.no,.oera.no,.nais.io,.aivencloud.com,.intern.dev.nav.no

--- a/pkg/controllers/application.go
+++ b/pkg/controllers/application.go
@@ -5,6 +5,7 @@ import (
 
 	nais_io_v1alpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 type ApplicationReconciler struct {
@@ -25,8 +26,9 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return r.synchronizer.Reconcile(ctx, req, &nais_io_v1alpha1.Application{})
 }
 
-func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager, opts ...func(*controller.Options)) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&nais_io_v1alpha1.Application{}).
+		WithOptions(options(opts)).
 		Complete(r)
 }

--- a/pkg/controllers/naisjob.go
+++ b/pkg/controllers/naisjob.go
@@ -5,6 +5,7 @@ import (
 
 	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 type NaisjobReconciler struct {
@@ -25,8 +26,9 @@ func (r *NaisjobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return r.synchronizer.Reconcile(ctx, req, &nais_io_v1.Naisjob{})
 }
 
-func (r *NaisjobReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *NaisjobReconciler) SetupWithManager(mgr ctrl.Manager, opts ...func(*controller.Options)) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&nais_io_v1.Naisjob{}).
+		WithOptions(options(opts)).
 		Complete(r)
 }

--- a/pkg/controllers/options.go
+++ b/pkg/controllers/options.go
@@ -1,0 +1,19 @@
+package controllers
+
+import "sigs.k8s.io/controller-runtime/pkg/controller"
+
+func options(opts []func(*controller.Options)) controller.Options {
+	o := &controller.Options{}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return *o
+}
+
+func WithMaxConcurrentReconciles(n int) func(*controller.Options) {
+	return func(o *controller.Options) {
+		o.MaxConcurrentReconciles = n
+	}
+}

--- a/pkg/naiserator/config/config.go
+++ b/pkg/naiserator/config/config.go
@@ -146,6 +146,7 @@ type Config struct {
 	AivenProject                      string           `json:"aiven-project"`
 	FQDNPolicy                        FQDNPolicy       `json:"fqdn-policy"`
 	Frontend                          Frontend         `json:"frontend"`
+	MaxConcurrentReconciles           int              `json:"max-concurrent-reconciles"`
 }
 
 const (
@@ -186,6 +187,7 @@ const (
 	KafkaTopic                          = "kafka.topic"
 	KubeConfig                          = "kubeconfig"
 	LeaderElectionImage                 = "leader-election.image"
+	MaxConcurrentReconciles             = "max-concurrent-reconciles"
 	ProxyAddress                        = "proxy.address"
 	ProxyExclude                        = "proxy.exclude"
 	RateLimitBurst                      = "ratelimit.burst"
@@ -260,6 +262,7 @@ func init() {
 		"how often to run a full synchronization of all applications",
 	)
 
+	flag.Int(MaxConcurrentReconciles, 1, "maximum number of concurrent Reconciles which can be run by the controller.")
 	flag.Int(RateLimitQPS, 20, "how quickly the rate limit burst bucket is filled per second")
 	flag.Int(RateLimitBurst, 200, "how many requests to Kubernetes to allow per second")
 


### PR DESCRIPTION
The controller-runtime default configuration allows controllers to reconcile resources with a maximum concurrency of 1.

The changes here enables configuration of the maximum concurrent reconciles for the controllers, which will allow them to concurrently reconcile distinct resources (though one should also take care to increase the qps/burst rate limits to prevent throttling). This is useful in cases like mass resynchronization of the `Application` or `Naisjob` resources.