### PR TITLE
netpol: use `kubernetes.io/metadata.name` as namespace selector label

### DIFF
--- a/charts/naiserator/templates/netpol.yaml
+++ b/charts/naiserator/templates/netpol.yaml
@@ -66,7 +66,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: nais-system
+          kubernetes.io/metadata.name: nais-system
       podSelector:
         matchLabels:
           app.kubernetes.io/name: prometheus

--- a/pkg/resourcecreator/networkpolicy/networkpolicy.go
+++ b/pkg/resourcecreator/networkpolicy/networkpolicy.go
@@ -108,7 +108,7 @@ func egressRulesFromAccessPolicy(policy *nais_io_v1.AccessPolicy, cfg Config) []
 		}
 
 		if rule.Namespace != "" {
-			peer.NamespaceSelector = labelSelector("name", rule.Namespace)
+			peer.NamespaceSelector = labelSelector("kubernetes.io/metadata.name", rule.Namespace)
 		}
 
 		peers = append(peers, peer)
@@ -202,7 +202,7 @@ func ingressRulesFromIngress(ingress []nais_io_v1.Ingress, cfg Config) []network
 				rules = append(rules, networkingv1.NetworkPolicyIngressRule{
 					From: []networkingv1.NetworkPolicyPeer{
 						{
-							NamespaceSelector: labelSelector("name", "nginx"),
+							NamespaceSelector: labelSelector("kubernetes.io/metadata.name", "nginx"),
 							PodSelector:       &metav1.LabelSelector{},
 						},
 					},
@@ -212,7 +212,7 @@ func ingressRulesFromIngress(ingress []nais_io_v1.Ingress, cfg Config) []network
 			rules = append(rules, networkingv1.NetworkPolicyIngressRule{
 				From: []networkingv1.NetworkPolicyPeer{
 					{
-						NamespaceSelector: labelSelector("name", ns),
+						NamespaceSelector: labelSelector("kubernetes.io/metadata.name", ns),
 						PodSelector:       ls,
 					},
 				},
@@ -227,7 +227,7 @@ func defaultIngressRules(cfg Config) []networkingv1.NetworkPolicyIngressRule {
 		{
 			From: []networkingv1.NetworkPolicyPeer{
 				{
-					NamespaceSelector: labelSelector("name", cfg.GetNaisNamespace()),
+					NamespaceSelector: labelSelector("kubernetes.io/metadata.name", cfg.GetNaisNamespace()),
 					PodSelector:       labelSelector("app.kubernetes.io/name", "prometheus"),
 				},
 			},
@@ -283,7 +283,7 @@ func ingressRulesFromAccessPolicy(policy *nais_io_v1.AccessPolicy, options Confi
 		if rule.Namespace == "*" {
 			peer.NamespaceSelector = &metav1.LabelSelector{}
 		} else if rule.Namespace != "" {
-			peer.NamespaceSelector = labelSelector("name", rule.Namespace)
+			peer.NamespaceSelector = labelSelector("kubernetes.io/metadata.name", rule.Namespace)
 		}
 
 		peers = append(peers, peer)

--- a/pkg/resourcecreator/observability/observability.go
+++ b/pkg/resourcecreator/observability/observability.go
@@ -3,11 +3,12 @@ package observability
 import (
 	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
 	"github.com/nais/liberator/pkg/namegen"
-	"github.com/nais/naiserator/pkg/resourcecreator/resource"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/nais/naiserator/pkg/resourcecreator/resource"
 )
 
 type Source interface {
@@ -67,7 +68,7 @@ func netpol(source Source) (*networkingv1.NetworkPolicy, error) {
 							},
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"name": "nais-system",
+									"kubernetes.io/metadata.name": "nais-system",
 								},
 							},
 						},

--- a/pkg/resourcecreator/testdata/accesspolicy_ingress.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_ingress.yaml
@@ -46,14 +46,14 @@ tests:
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
                     podSelector:
                       matchLabels:
                         nais.io/ingressClass: nais-ingress
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
                     podSelector:
                       matchLabels:
                         nais.io/ingressClass: nais-ingress-external

--- a/pkg/resourcecreator/testdata/accesspolicy_ingress_allow_all.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_ingress_allow_all.yaml
@@ -50,7 +50,7 @@ tests:
                         app.kubernetes.io/name: prometheus
                     namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
               - from:
                   - namespaceSelector: {}
                     podSelector: {}

--- a/pkg/resourcecreator/testdata/accesspolicy_legacy_gcp.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_legacy_gcp.yaml
@@ -100,28 +100,28 @@ tests:
                         app.kubernetes.io/name: prometheus
                     namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nginx
+                        kubernetes.io/metadata.name: nginx
                     podSelector: {}
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
                     podSelector:
                       matchLabels:
                         nais.io/ingressClass: adeo-gateway
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nginx
+                        kubernetes.io/metadata.name: nginx
                     podSelector: {}
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
                     podSelector:
                       matchLabels:
                         nais.io/ingressClass: domain-gateway
@@ -134,11 +134,11 @@ tests:
                         app: app2
                     namespaceSelector:
                       matchLabels:
-                        name: q1
+                        kubernetes.io/metadata.name: q1
                   - podSelector: { }
                     namespaceSelector:
                       matchLabels:
-                        name: t1
+                        kubernetes.io/metadata.name: t1
             egress:
               - to:
                   - podSelector:
@@ -154,7 +154,7 @@ tests:
                         app: app4
                     namespaceSelector:
                       matchLabels:
-                        name: q2
+                        kubernetes.io/metadata.name: q2
             policyTypes:
               - Ingress
               - Egress

--- a/pkg/resourcecreator/testdata/accesspolicy_max.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_max.yaml
@@ -75,7 +75,7 @@ tests:
                         app.kubernetes.io/name: prometheus
                     namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
               - from:
                   - podSelector:
                       matchLabels:
@@ -85,11 +85,11 @@ tests:
                         app: app2
                     namespaceSelector:
                       matchLabels:
-                        name: q1
+                        kubernetes.io/metadata.name: q1
                   - podSelector: { }
                     namespaceSelector:
                       matchLabels:
-                        name: t1
+                        kubernetes.io/metadata.name: t1
             egress:
               - to:
                   - podSelector:
@@ -105,7 +105,7 @@ tests:
                         app: app4
                     namespaceSelector:
                       matchLabels:
-                        name: q2
+                        kubernetes.io/metadata.name: q2
             policyTypes:
               - Ingress
               - Egress

--- a/pkg/resourcecreator/testdata/accesspolicy_only_other_clusters.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_only_other_clusters.yaml
@@ -51,7 +51,7 @@ tests:
                         app.kubernetes.io/name: prometheus
                     namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
             egress:
               - to:
                 - podSelector:

--- a/pkg/resourcecreator/testdata/accesspolicy_tokenx.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_tokenx.yaml
@@ -46,7 +46,7 @@ tests:
               - to:
                   - namespaceSelector:
                       matchLabels:
-                        name: bar
+                        kubernetes.io/metadata.name: bar
                     podSelector:
                       matchLabels:
                         app: foo

--- a/pkg/resourcecreator/testdata/leader_election.yaml
+++ b/pkg/resourcecreator/testdata/leader_election.yaml
@@ -113,7 +113,7 @@ tests:
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
                     podSelector:
                       matchLabels:
                         app.kubernetes.io/name: prometheus

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_accesspolicy_egress.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_accesspolicy_egress.yaml
@@ -42,7 +42,7 @@ tests:
               - to:
                   - namespaceSelector:
                       matchLabels:
-                        name: bar
+                        kubernetes.io/metadata.name: bar
                     podSelector:
                       matchLabels:
                         app: foo

--- a/pkg/resourcecreator/testdata/observability_tracing_enabled.yaml
+++ b/pkg/resourcecreator/testdata/observability_tracing_enabled.yaml
@@ -50,7 +50,7 @@ tests:
               - to:
                 - namespaceSelector:
                     matchLabels:
-                      name: nais-system
+                      kubernetes.io/metadata.name: nais-system
                   podSelector:
                     matchLabels:
                       app.kubernetes.io/instance: tempo

--- a/pkg/resourcecreator/testdata/vanilla.yaml
+++ b/pkg/resourcecreator/testdata/vanilla.yaml
@@ -111,7 +111,7 @@ tests:
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
                     podSelector:
                       matchLabels:
                         app.kubernetes.io/name: prometheus

--- a/pkg/resourcecreator/testdata/vanilla_legacy_gcp.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_legacy_gcp.yaml
@@ -132,7 +132,7 @@ tests:
               - from:
                   - namespaceSelector:
                       matchLabels:
-                        name: nais-system
+                        kubernetes.io/metadata.name: nais-system
                     podSelector:
                       matchLabels:
                         app.kubernetes.io/name: prometheus


### PR DESCRIPTION
Use the `kubernetes.io/metadata.name` label, which the API server sets for all namespaces with uniqueness and immutability guarantees. Its value is set to the name of the namespace.

https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name