### PR TITLE
Add support for GOOGLE_CLOUD_PROJECT environment variable

### DIFF
--- a/pkg/resourcecreator/google/gcp/gcp.go
+++ b/pkg/resourcecreator/google/gcp/gcp.go
@@ -41,6 +41,14 @@ func Create(source Source, ast *resource.Ast, cfg Config) error {
 
 	googleServiceAccount := google_iam.CreateServiceAccount(source, projectID)
 	googleServiceAccountBinding := google_iam.CreatePolicy(source, &googleServiceAccount, projectID)
+
+	// Standard environment variable name in Google SDKs
+	ast.Env = append(ast.Env, v1.EnvVar{
+		Name:  "GOOGLE_CLOUD_PROJECT",
+		Value: teamProjectID,
+	})
+
+	// Legacy environment variable for backwards compability
 	ast.Env = append(ast.Env, v1.EnvVar{
 		Name:  "GCP_TEAM_PROJECT_ID",
 		Value: teamProjectID,

--- a/pkg/resourcecreator/testdata/gcp_bigquery.yaml
+++ b/pkg/resourcecreator/testdata/gcp_bigquery.yaml
@@ -87,6 +87,8 @@ tests:
                 containers:
                   - image: navikt/myapplication:1.2.3
                     env:
+                      - name: GOOGLE_CLOUD_PROJECT
+                        value: team-project-id
                       - name: GCP_TEAM_PROJECT_ID
                         value: team-project-id
                 dnsPolicy: ClusterFirst

--- a/pkg/resourcecreator/testdata/gcp_bigquery_cascading_delete.yaml
+++ b/pkg/resourcecreator/testdata/gcp_bigquery_cascading_delete.yaml
@@ -90,6 +90,8 @@ tests:
                 containers:
                   - image: navikt/myapplication:1.2.3
                     env:
+                      - name: GOOGLE_CLOUD_PROJECT
+                        value: team-project-id
                       - name: GCP_TEAM_PROJECT_ID
                         value: team-project-id
                 dnsPolicy: ClusterFirst

--- a/pkg/resourcecreator/testdata/gcp_buckets.yaml
+++ b/pkg/resourcecreator/testdata/gcp_buckets.yaml
@@ -138,6 +138,8 @@ tests:
                 containers:
                   - image: navikt/myapplication:1.2.3
                     env:
+                      - name: GOOGLE_CLOUD_PROJECT
+                        value: team-project-id
                       - name: GCP_TEAM_PROJECT_ID
                         value: team-project-id
                 dnsPolicy: ClusterFirst

--- a/pkg/resourcecreator/testdata/gcp_buckets_publicaccessprevention.yaml
+++ b/pkg/resourcecreator/testdata/gcp_buckets_publicaccessprevention.yaml
@@ -128,6 +128,8 @@ tests:
                 containers:
                   - image: navikt/myapplication:1.2.3
                     env:
+                      - name: GOOGLE_CLOUD_PROJECT
+                        value: team-project-id
                       - name: GCP_TEAM_PROJECT_ID
                         value: team-project-id
                 dnsPolicy: ClusterFirst

--- a/pkg/resourcecreator/testdata/gcp_buckets_uniformlevelaccess.yaml
+++ b/pkg/resourcecreator/testdata/gcp_buckets_uniformlevelaccess.yaml
@@ -167,6 +167,8 @@ tests:
                 containers:
                   - image: navikt/myapplication:1.2.3
                     env:
+                      - name: GOOGLE_CLOUD_PROJECT
+                        value: team-project-id
                       - name: GCP_TEAM_PROJECT_ID
                         value: team-project-id
                 dnsPolicy: ClusterFirst

--- a/pkg/resourcecreator/testdata/gcp_buckets_with_lifecycle_and_retention.yaml
+++ b/pkg/resourcecreator/testdata/gcp_buckets_with_lifecycle_and_retention.yaml
@@ -151,6 +151,8 @@ tests:
                 containers:
                   - image: navikt/myapplication:1.2.3
                     env:
+                      - name: GOOGLE_CLOUD_PROJECT
+                        value: team-project-id
                       - name: GCP_TEAM_PROJECT_ID
                         value: team-project-id
                 dnsPolicy: ClusterFirst

--- a/pkg/resourcecreator/testdata/gcp_database.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database.yaml
@@ -224,6 +224,8 @@ tests:
                       - secretRef:
                           name: google-sql-myapplication
                     env:
+                      - name: GOOGLE_CLOUD_PROJECT
+                        value: team-project-id
                       - name: GCP_TEAM_PROJECT_ID
                         value: team-project-id
                   - name: cloudsql-proxy

--- a/pkg/resourcecreator/testdata/gcp_database_with_insights.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database_with_insights.yaml
@@ -223,6 +223,8 @@ tests:
                       - secretRef:
                           name: google-sql-myapplication
                     env:
+                      - name: GOOGLE_CLOUD_PROJECT
+                        value: team-project-id
                       - name: GCP_TEAM_PROJECT_ID
                         value: team-project-id
                   - name: cloudsql-proxy

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_bigquery_cascading_delete.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_bigquery_cascading_delete.yaml
@@ -93,6 +93,8 @@ tests:
                     containers:
                       - image: navikt/mynaisjob:1.2.3
                         env:
+                          - name: GOOGLE_CLOUD_PROJECT
+                            value: team-project-id
                           - name: GCP_TEAM_PROJECT_ID
                             value: team-project-id
                     dnsPolicy: ClusterFirst

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_buckets.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_buckets.yaml
@@ -143,6 +143,8 @@ tests:
                     containers:
                       - image: navikt/mynaisjob:1.2.3
                         env:
+                          - name: GOOGLE_CLOUD_PROJECT
+                            value: team-project-id
                           - name: GCP_TEAM_PROJECT_ID
                             value: team-project-id
                     dnsPolicy: ClusterFirst

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database.yaml
@@ -216,6 +216,8 @@ tests:
                           - secretRef:
                               name: google-sql-mynaisjob
                         env:
+                          - name: GOOGLE_CLOUD_PROJECT
+                            value: team-project-id
                           - name: GCP_TEAM_PROJECT_ID
                             value: team-project-id
                       - name: cloudsql-proxy


### PR DESCRIPTION
The `GOOGLE_CLOUD_PROJECT` environment variable is default in Google SDKs which
means less manual configurations for teams authetnticating to Google Cloud.

* java https://github.com/googleapis/google-cloud-java/blob/cc0e248a9ee4658dbd3b2649d01381df218b4419/README.md?plain=1#L214
* node https://github.com/googleapis/google-cloud-node/blob/489e188d97af302f96299a5b40eb5e07020972fc/docs/authentication.md?plain=1#L25

