### PR TITLE
Remove Cloud SQL proxy CPU limit

### DIFF
--- a/pkg/resourcecreator/google/helpers.go
+++ b/pkg/resourcecreator/google/helpers.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
-	"github.com/nais/naiserator/pkg/resourcecreator/pod"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/nais/naiserator/pkg/resourcecreator/pod"
 )
 
 func GcpServiceAccountName(appNamespaceHash, projectId string) string {
@@ -16,12 +17,8 @@ func GcpServiceAccountName(appNamespaceHash, projectId string) string {
 func CloudSqlProxyContainer(port int32, googleCloudSQLProxyContainerImage, projectId, instanceName string) corev1.Container {
 	connectionName := fmt.Sprintf("%s:%s:%s", projectId, Region, instanceName)
 	cloudSqlProxyContainerResourceSpec := nais_io_v1.ResourceRequirements{
-		Limits: &nais_io_v1.ResourceSpec{
-			Cpu:    "250m",
-			Memory: "256Mi",
-		},
 		Requests: &nais_io_v1.ResourceSpec{
-			Cpu:    "20m",
+			Cpu:    "50m",
 			Memory: "32Mi",
 		},
 	}

--- a/pkg/resourcecreator/google/helpers.go
+++ b/pkg/resourcecreator/google/helpers.go
@@ -17,6 +17,9 @@ func GcpServiceAccountName(appNamespaceHash, projectId string) string {
 func CloudSqlProxyContainer(port int32, googleCloudSQLProxyContainerImage, projectId, instanceName string) corev1.Container {
 	connectionName := fmt.Sprintf("%s:%s:%s", projectId, Region, instanceName)
 	cloudSqlProxyContainerResourceSpec := nais_io_v1.ResourceRequirements{
+		Limits: &nais_io_v1.ResourceSpec{
+			Memory: "256Mi",
+		},
 		Requests: &nais_io_v1.ResourceSpec{
 			Cpu:    "50m",
 			Memory: "32Mi",

--- a/pkg/resourcecreator/pod/helpers.go
+++ b/pkg/resourcecreator/pod/helpers.go
@@ -54,18 +54,25 @@ func EnvFromSecret(name string) corev1.EnvFromSource {
 }
 
 func ResourceLimits(reqs nais_io_v1.ResourceRequirements) corev1.ResourceRequirements {
-	limits := corev1.ResourceList{
-		corev1.ResourceMemory: k8sResource.MustParse(reqs.Limits.Memory),
+	requests := make(corev1.ResourceList)
+	limits := make(corev1.ResourceList)
+
+	if reqs.Limits != nil {
+		limits[corev1.ResourceMemory] = k8sResource.MustParse(reqs.Limits.Memory)
+		if len(reqs.Limits.Cpu) > 0 {
+			limits[corev1.ResourceCPU] = k8sResource.MustParse(reqs.Limits.Cpu)
+		}
 	}
-	if len(reqs.Limits.Cpu) > 0 {
-		limits[corev1.ResourceCPU] = k8sResource.MustParse(reqs.Limits.Cpu)
+
+	if reqs.Requests != nil {
+		requests[corev1.ResourceMemory] = k8sResource.MustParse(reqs.Requests.Memory)
+		if len(reqs.Requests.Cpu) > 0 {
+			requests[corev1.ResourceCPU] = k8sResource.MustParse(reqs.Requests.Cpu)
+		}
 	}
 	return corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    k8sResource.MustParse(reqs.Requests.Cpu),
-			corev1.ResourceMemory: k8sResource.MustParse(reqs.Requests.Memory),
-		},
-		Limits: limits,
+		Requests: requests,
+		Limits:   limits,
 	}
 }
 

--- a/pkg/resourcecreator/testdata/gcp_database.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database.yaml
@@ -237,11 +237,8 @@ tests:
                       - containerPort: 5432
                         protocol: TCP
                     resources:
-                      limits:
-                        cpu: 250m
-                        memory: 256Mi
                       requests:
-                        cpu: 20m
+                        cpu: 50m
                         memory: 32Mi
                     imagePullPolicy: IfNotPresent
                     securityContext:

--- a/pkg/resourcecreator/testdata/gcp_database.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database.yaml
@@ -237,6 +237,8 @@ tests:
                       - containerPort: 5432
                         protocol: TCP
                     resources:
+                      limits:
+                        memory: 256Mi
                       requests:
                         cpu: 50m
                         memory: 32Mi


### PR DESCRIPTION
Benchmarks with pgbench has shown that applications with high traffic are severely limited by the CPU resourc limits. This commits removes the limit, but keeps the request.

Also, CPU request is bumped by 150%, up to 50 millicpu.