### PR TITLE
Upgrade Google Cloud SQL proxy to version 2.8

### DIFF
--- a/charts/naiserator/Chart.yaml
+++ b/charts/naiserator/Chart.yaml
@@ -4,4 +4,4 @@ name: naiserator
 description: creates k8s resources based on application spec
 sources:
   - https://github.com/nais/naiserator/tree/master/charts
-version: 2.0.2
+version: 2.1.0

--- a/charts/naiserator/values.yaml
+++ b/charts/naiserator/values.yaml
@@ -19,7 +19,7 @@ naiserator:
   bind: 0.0.0.0:8080
   cluster-name: ""
   google-project-id: ""
-  google-cloud-sql-proxy-container-image: "gcr.io/cloudsql-docker/gce-proxy:1.33.9-alpine"
+  google-cloud-sql-proxy-container-image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8-alpine"
   api-server-ip: ""
   host-aliases: ""
   nais-namespace: "nais-system"

--- a/pkg/resourcecreator/google/helpers.go
+++ b/pkg/resourcecreator/google/helpers.go
@@ -35,8 +35,9 @@ func CloudSqlProxyContainer(port int32, googleCloudSQLProxyContainerImage, proje
 			ContainerPort: port,
 			Protocol:      corev1.ProtocolTCP,
 		}},
+		// Needs version 2.x of Cloud SQL proxy
 		Command: []string{
-			"/cloud_sql_proxy",
+			"/cloud-sql-proxy",
 			"--max-sigterm-delay", CloudSQLProxyTermTimeout,
 			"--port", strconv.Itoa(int(port)),
 			connectionName,

--- a/pkg/resourcecreator/google/helpers.go
+++ b/pkg/resourcecreator/google/helpers.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strconv"
 
 	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,8 +37,9 @@ func CloudSqlProxyContainer(port int32, googleCloudSQLProxyContainerImage, proje
 		}},
 		Command: []string{
 			"/cloud_sql_proxy",
-			fmt.Sprintf("-term_timeout=%s", CloudSQLProxyTermTimeout),
-			fmt.Sprintf("-instances=%s=tcp:%d", connectionName, port),
+			"--max-sigterm-delay", CloudSQLProxyTermTimeout,
+			"--port", strconv.Itoa(int(port)),
+			connectionName,
 		},
 		Resources: pod.ResourceLimits(cloudSqlProxyContainerResourceSpec),
 		SecurityContext: &corev1.SecurityContext{

--- a/pkg/resourcecreator/testdata/gcp_database.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database.yaml
@@ -231,8 +231,11 @@ tests:
                   - name: cloudsql-proxy
                     command:
                       - /cloud_sql_proxy
-                      - -term_timeout=30s
-                      - -instances=team-project-id:europe-north1:myapplication=tcp:5432
+                      - --max-sigterm-delay
+                      - 30s
+                      - --port
+                      - "5432"
+                      - team-project-id:europe-north1:myapplication
                     ports:
                       - containerPort: 5432
                         protocol: TCP

--- a/pkg/resourcecreator/testdata/gcp_database.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database.yaml
@@ -230,7 +230,7 @@ tests:
                         value: team-project-id
                   - name: cloudsql-proxy
                     command:
-                      - /cloud_sql_proxy
+                      - /cloud-sql-proxy
                       - --max-sigterm-delay
                       - 30s
                       - --port

--- a/pkg/resourcecreator/testdata/gcp_database_with_insights.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database_with_insights.yaml
@@ -230,8 +230,11 @@ tests:
                   - name: cloudsql-proxy
                     command:
                       - /cloud_sql_proxy
-                      - -term_timeout=30s
-                      - -instances=team-project-id:europe-north1:myapplication=tcp:5432
+                      - --max-sigterm-delay
+                      - 30s
+                      - --port
+                      - "5432"
+                      - team-project-id:europe-north1:myapplication
                     ports:
                       - containerPort: 5432
                         protocol: TCP

--- a/pkg/resourcecreator/testdata/gcp_database_with_insights.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database_with_insights.yaml
@@ -229,7 +229,7 @@ tests:
                         value: team-project-id
                   - name: cloudsql-proxy
                     command:
-                      - /cloud_sql_proxy
+                      - /cloud-sql-proxy
                       - --max-sigterm-delay
                       - 30s
                       - --port

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database.yaml
@@ -222,7 +222,7 @@ tests:
                             value: team-project-id
                       - name: cloudsql-proxy
                         command:
-                          - /cloud_sql_proxy
+                          - /cloud-sql-proxy
                           - --max-sigterm-delay
                           - 30s
                           - --port

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database.yaml
@@ -223,8 +223,11 @@ tests:
                       - name: cloudsql-proxy
                         command:
                           - /cloud_sql_proxy
-                          - -term_timeout=30s
-                          - -instances=team-project-id:europe-north1:mynaisjob=tcp:5432
+                          - --max-sigterm-delay
+                          - 30s
+                          - --port
+                          - "5432"
+                          - team-project-id:europe-north1:mynaisjob
                         ports:
                           - containerPort: 5432
                             protocol: TCP

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/nais/liberator/pkg/crd"
 	"github.com/nais/liberator/pkg/events"
 	liberator_scheme "github.com/nais/liberator/pkg/scheme"
-	"github.com/nais/naiserator/pkg/generators"
-	resourcecreator_secret "github.com/nais/naiserator/pkg/resourcecreator/secret"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/nais/naiserator/pkg/generators"
+	resourcecreator_secret "github.com/nais/naiserator/pkg/resourcecreator/secret"
 
 	"github.com/nais/naiserator/pkg/controllers"
 	"github.com/nais/naiserator/pkg/naiserator/config"
@@ -494,8 +495,8 @@ func TestSynchronizerResourceOptions(t *testing.T) {
 
 	err = rig.client.Get(ctx, req.NamespacedName, deploy)
 	assert.NoError(t, err)
-	expectedInstanceName := fmt.Sprintf("-instances=%s:%s:%s=tcp:5432", testProjectId, google.Region, app.Name)
-	assert.Equal(t, expectedInstanceName, deploy.Spec.Template.Spec.Containers[1].Command[2])
+	expectedInstanceName := fmt.Sprintf("%s:%s:%s", testProjectId, google.Region, app.Name)
+	assert.Equal(t, expectedInstanceName, deploy.Spec.Template.Spec.Containers[1].Command[5])
 
 	err = rig.client.Get(ctx, req.NamespacedName, sqlinstance)
 	assert.NoError(t, err)


### PR DESCRIPTION
Previous version 1.33.9; followed release notes/upgrade guide at:
https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/0184be312bba666a6a74d799bfc3c216dfdd812f/migration-guide.md