### PR TITLE
Use OpenTelemetry Collector endpoint for Trace config

### DIFF
--- a/charts/naiserator/Feature.yaml
+++ b/charts/naiserator/Feature.yaml
@@ -174,6 +174,9 @@ values:
     displayName: Enable Kafka
     config:
       type: bool
+  naiserator.observability.otel.enabled:
+    computed:
+      template: '{{ne .Kind "onprem"}}'
   naiserator.observability.logging.destinations:
     computed:
       # Find all logging_*_default_flow environment variables and use for configuration of available log destinations

--- a/charts/naiserator/values.yaml
+++ b/charts/naiserator/values.yaml
@@ -56,6 +56,18 @@ naiserator:
       insecure: false
     topic: aura.dev-rapid
   max-concurrent-reconciles: 20
+  observability:
+    otel:
+      enabled: false
+      collector:
+        labels:
+          - "app.kubernetes.io/name=opentelemetry-collector"
+          - "app.kubernetes.io/instance=nais-system.opentelemetry"
+        namespace: "nais-system"
+        port: 4317
+        service: "opentelemetry-collector"
+        tls: false
+        protocol: "grpc"
   proxy:
     address: ""
     exclude: ""

--- a/pkg/naiserator/config/config.go
+++ b/pkg/naiserator/config/config.go
@@ -67,6 +67,21 @@ type Features struct {
 
 type Observability struct {
 	Logging Logging `json:"logging"`
+	Otel    Otel    `json:"otel"`
+}
+
+type Otel struct {
+	Enabled   bool          `json:"enabled"`
+	Collector OtelCollector `json:"collector"`
+}
+
+type OtelCollector struct {
+	Labels    []string `json:"labels"`
+	Namespace string   `json:"namespace"`
+	Port      int      `json:"port"`
+	Protocol  string   `json:"protocol"`
+	Service   string   `json:"service"`
+	Tls       bool     `json:"tls"`
 }
 
 type Logging struct {
@@ -199,6 +214,13 @@ const (
 	LeaderElectionImage                 = "leader-election.image"
 	MaxConcurrentReconciles             = "max-concurrent-reconciles"
 	ObservabilityLoggingDestinations    = "observability.logging.destinations"
+	ObservabilityOtelCollectorLabels    = "observability.otel.collector.labels"
+	ObservabilityOtelCollectorNamespace = "observability.otel.collector.namespace"
+	ObservabilityOtelCollectorPort      = "observability.otel.collector.port"
+	ObservabilityOtelCollectorProtocol  = "observability.otel.collector.protocol"
+	ObservabilityOtelCollectorService   = "observability.otel.collector.service"
+	ObservabilityOtelCollectorTLS       = "observability.otel.collector.tls"
+	ObservabilityOtelEnabled            = "observability.otel.enabled"
 	ProxyAddress                        = "proxy.address"
 	ProxyExclude                        = "proxy.exclude"
 	RateLimitBurst                      = "ratelimit.burst"
@@ -277,6 +299,13 @@ func init() {
 	flag.String(LeaderElectionImage, "", "image to use for leader election in deployed applications")
 	flag.Int(MaxConcurrentReconciles, 1, "maximum number of concurrent Reconciles which can be run by the controller.")
 	flag.StringArray(ObservabilityLoggingDestinations, []string{}, "list of valid logging destinations")
+	flag.Bool(ObservabilityOtelEnabled, false, "enable OpenTelemetry")
+	flag.String(ObservabilityOtelCollectorNamespace, "nais-system", "namespace of the OpenTelemetry collector")
+	flag.String(ObservabilityOtelCollectorService, "opentelmetry-collector", "service name of the OpenTelemetry collector")
+	flag.String(ObservabilityOtelCollectorProtocol, "grpc", "protocol used by the OpenTelemetry collector")
+	flag.Int(ObservabilityOtelCollectorPort, 4317, "port used by the OpenTelemetry collector")
+	flag.Bool(ObservabilityOtelCollectorTLS, false, "use TLS for the OpenTelemetry collector")
+	flag.StringArray(ObservabilityOtelCollectorLabels, []string{}, "list of labels to be used by the OpenTelemetry collector")
 	flag.Int(RateLimitQPS, 20, "how quickly the rate limit burst bucket is filled per second")
 	flag.Int(RateLimitBurst, 200, "how many requests to Kubernetes to allow per second")
 

--- a/pkg/resourcecreator/observability/observability.go
+++ b/pkg/resourcecreator/observability/observability.go
@@ -147,7 +147,11 @@ func Create(source Source, ast *resource.Ast, config Config) error {
 		return nil
 	}
 
-	if cfg.Otel.Enabled && obs.Tracing != nil && obs.Tracing.Enabled {
+	if obs.Tracing != nil && obs.Tracing.Enabled {
+		if !cfg.Otel.Enabled {
+			return fmt.Errorf("tracing is not supported in this cluster configuration")
+		}
+
 		netpol, err := tracingNetpol(source, cfg.Otel)
 		if err != nil {
 			return err

--- a/pkg/resourcecreator/observability/observability_test.go
+++ b/pkg/resourcecreator/observability/observability_test.go
@@ -1,0 +1,231 @@
+package observability
+
+import (
+	"testing"
+
+	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
+	nais_io_v1alpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
+	"github.com/nais/liberator/pkg/namegen"
+	"github.com/nais/naiserator/pkg/naiserator/config"
+	"github.com/nais/naiserator/pkg/resourcecreator/resource"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestOtelEndpointFromConfig(t *testing.T) {
+	testCases := []struct {
+		name             string
+		collector        config.OtelCollector
+		expectedEndpoint string
+	}{
+		{
+			name: "TLS disabled",
+			collector: config.OtelCollector{
+				Tls:       false,
+				Service:   "my-service",
+				Namespace: "my-namespace",
+				Port:      8080,
+			},
+			expectedEndpoint: "http://my-service.my-namespace:8080",
+		},
+		{
+			name: "TLS enabled",
+			collector: config.OtelCollector{
+				Tls:       true,
+				Service:   "my-service",
+				Namespace: "my-namespace",
+				Port:      8080,
+			},
+			expectedEndpoint: "https://my-service.my-namespace:8080",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualEndpoint := otelEndpointFromConfig(tc.collector)
+			assert.Equal(t, tc.expectedEndpoint, actualEndpoint)
+		})
+	}
+}
+
+func TestOtelEnvVars(t *testing.T) {
+	app := nais_io_v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "my-namespace",
+		},
+		Spec: nais_io_v1alpha1.ApplicationSpec{
+			Observability: &nais_io_v1.Observability{
+				Tracing: &nais_io_v1.Tracing{
+					Enabled: true,
+				},
+			},
+		},
+	}
+	otel := config.Otel{
+		Collector: config.OtelCollector{
+			Tls:       false,
+			Service:   "my-service",
+			Namespace: "my-namespace",
+			Port:      8080,
+			Protocol:  "grcp",
+		},
+	}
+
+	expectedEnvVars := []corev1.EnvVar{
+		{
+			Name:  "OTEL_SERVICE_NAME",
+			Value: "my-app",
+		},
+		{
+			Name:  "OTEL_RESOURCE_ATTRIBUTES",
+			Value: "service.name=my-app,service.namespace=my-namespace",
+		},
+		{
+			Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+			Value: "http://my-service.my-namespace:8080",
+		},
+		{
+			Name:  "OTEL_EXPORTER_OTLP_PROTOCOL",
+			Value: "grcp",
+		},
+		{
+			Name:  "OTEL_EXPORTER_OTLP_INSECURE",
+			Value: "true",
+		},
+	}
+
+	actualEnvVars := otelEnvVars(&app, otel)
+
+	assert.Equal(t, expectedEnvVars, actualEnvVars)
+}
+func TestLabelsFromCollectorConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		collector      config.OtelCollector
+		expectedLabels map[string]string
+	}{
+		{
+			name: "Valid labels",
+			collector: config.OtelCollector{
+				Labels: []string{"key1=value1", "key2=value2", "key3=value3"},
+			},
+			expectedLabels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "Invalid labels",
+			collector: config.OtelCollector{
+				Labels: []string{"key1=value1", "key2=value2", "key3"},
+			},
+			expectedLabels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Empty labels",
+			collector: config.OtelCollector{
+				Labels: []string{},
+			},
+			expectedLabels: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualLabels := labelsFromCollectorConfig(tc.collector)
+			assert.Equal(t, tc.expectedLabels, actualLabels)
+		})
+	}
+}
+
+func TestTracingNetpol(t *testing.T) {
+	app := nais_io_v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "my-namespace",
+		},
+		Spec: nais_io_v1alpha1.ApplicationSpec{
+			Observability: &nais_io_v1.Observability{
+				Tracing: &nais_io_v1.Tracing{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	otel := config.Otel{
+		Collector: config.OtelCollector{
+			Labels:    []string{"key1=value1", "key2=value2", "key3=value3"},
+			Namespace: "my-namespace",
+			Port:      8080,
+			Protocol:  "grcp",
+			Service:   "my-service",
+			Tls:       false,
+		},
+	}
+
+	expectedName, err := namegen.ShortName(app.GetName()+"-"+"tracing", validation.DNS1035LabelMaxLength)
+	assert.NoError(t, err)
+
+	expectedObjectMeta := resource.CreateObjectMeta(&app)
+	expectedObjectMeta.Name = expectedName
+
+	expectedProtocolTCP := corev1.ProtocolTCP
+
+	expectedNetworkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: expectedObjectMeta,
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NetworkPolicy",
+			APIVersion: "networking.k8s.io/v1",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "my-app",
+				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &expectedProtocolTCP,
+							Port:     &intstr.IntOrString{IntVal: 8080},
+						},
+					},
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"key1": "value1",
+									"key2": "value2",
+									"key3": "value3",
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": "my-namespace",
+								},
+							},
+						},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeEgress,
+			},
+		},
+	}
+
+	actualNetworkPolicy, err := tracingNetpol(&app, otel)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedNetworkPolicy, actualNetworkPolicy)
+}

--- a/pkg/resourcecreator/testdata/observability_tracing_enabled.yaml
+++ b/pkg/resourcecreator/testdata/observability_tracing_enabled.yaml
@@ -1,6 +1,21 @@
 testconfig:
   description: inject opentelemetry tracing environment variable and network policy
 
+config:
+  observability:
+    otel:
+      enabled: true
+      collector:
+        labels:
+          - key1=value1
+          - key2=value2
+          - key3=value3
+        namespace: "my-system"
+        port: 4317
+        service: "my-collector"
+        tls: false
+        protocol: "grpc"
+
 input:
   kind: Application
   apiVersion: nais.io/v1alpha1
@@ -37,9 +52,11 @@ tests:
                       - name: OTEL_RESOURCE_ATTRIBUTES
                         value: service.name=myapplication,service.namespace=mynamespace
                       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                        value: http://tempo-distributor.nais-system:4317
+                        value: http://my-collector.my-system:4317
                       - name: OTEL_EXPORTER_OTLP_PROTOCOL
                         value: grpc
+                      - name: OTEL_EXPORTER_OTLP_INSECURE
+                        value: "true"
 
   - apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
@@ -52,9 +69,11 @@ tests:
           spec:
             egress:
               - to:
-                - namespaceSelector:
-                    matchLabels:
-                      kubernetes.io/metadata.name: nais-system
-                  podSelector:
-                    matchLabels:
-                      app.kubernetes.io/instance: tempo
+                  - namespaceSelector:
+                      matchLabels:
+                        kubernetes.io/metadata.name: my-system
+                    podSelector:
+                      matchLabels:
+                        key1: value1
+                        key2: value2
+                        key3: value3

--- a/pkg/resourcecreator/testdata/observability_tracing_enabled.yaml
+++ b/pkg/resourcecreator/testdata/observability_tracing_enabled.yaml
@@ -10,7 +10,7 @@ config:
           - key1=value1
           - key2=value2
           - key3=value3
-        namespace: "my-system"
+        namespace: "system-namespace"
         port: 4317
         service: "my-collector"
         tls: false
@@ -52,7 +52,7 @@ tests:
                       - name: OTEL_RESOURCE_ATTRIBUTES
                         value: service.name=myapplication,service.namespace=mynamespace
                       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                        value: http://my-collector.my-system:4317
+                        value: http://my-collector.system-namespace:4317
                       - name: OTEL_EXPORTER_OTLP_PROTOCOL
                         value: grpc
                       - name: OTEL_EXPORTER_OTLP_INSECURE
@@ -71,7 +71,7 @@ tests:
               - to:
                   - namespaceSelector:
                       matchLabels:
-                        kubernetes.io/metadata.name: my-system
+                        kubernetes.io/metadata.name: system-namespace
                     podSelector:
                       matchLabels:
                         key1: value1

--- a/pkg/resourcecreator/testdata/observability_tracing_enabled_error.yaml
+++ b/pkg/resourcecreator/testdata/observability_tracing_enabled_error.yaml
@@ -1,0 +1,24 @@
+testconfig:
+  description: inject opentelemetry tracing environment variable and network policy
+
+config:
+  observability:
+    otel:
+      enabled: false
+
+input:
+  kind: Application
+  apiVersion: nais.io/v1alpha1
+  metadata:
+    name: myapplication
+    namespace: mynamespace
+    uid: "123456"
+    labels:
+      team: myteam
+  spec:
+    image: navikt/myapplication:1.2.3
+    observability:
+      tracing:
+        enabled: true
+
+error: "tracing is not supported in this cluster configuration"


### PR DESCRIPTION
* Changed endpoint from tempo to opentelemetry collector
* Make it configurable if we want to change things later
* Refactored trace specifics to more generic otel names
* Better test coverage for observability utility functions
* Fail sync if otel is not configured for the cluster
