### PR TITLE
Adds default env vars for PORT and BIND_ADDRESS

### DIFF
--- a/pkg/resourcecreator/resource/source.go
+++ b/pkg/resourcecreator/resource/source.go
@@ -25,6 +25,7 @@ type Source interface {
 	GetObjectReference() corev1.ObjectReference
 	GetOwnerReference() metav1.OwnerReference
 	GetGCP() *nais_io_v1.GCP
+	GetPort() int
 	CorrelationID() string
 	SkipDeploymentMessage() bool
 	LogFields() log.Fields

--- a/pkg/resourcecreator/testdata/env.yaml
+++ b/pkg/resourcecreator/testdata/env.yaml
@@ -13,7 +13,10 @@ input:
     labels:
       team: myteam
   spec:
+    port: 6969
     env:
+      - name: PORT
+        value: 9000
       - name: foo
         value: bar
       - name: valuefrom
@@ -39,12 +42,18 @@ tests:
                 containers:
                   - name: myapplication
                     env:
+                      - name: PORT
+                        value: "9000"
                       - name: foo
                         value: bar
                       - name: valuefrom
                         valueFrom:
                           fieldRef:
                             fieldPath: status.podIP
+                      - name: PORT
+                        value: "6969"
+                      - name: BIND_ADDRESS
+                        value: "0.0.0.0:6969"
                     envFrom:
                       - configMapRef:
                           name: mycm

--- a/pkg/resourcecreator/testdata/gcp_gar_toleration_with_non_gar_image.yaml
+++ b/pkg/resourcecreator/testdata/gcp_gar_toleration_with_non_gar_image.yaml
@@ -64,6 +64,10 @@ tests:
                         value: :mynamespace:myapplication
                       - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
                         value: "true"
+                      - name: PORT
+                        value: "8080"
+                      - name: BIND_ADDRESS
+                        value: "0.0.0.0:8080"
                     image: ghcr.io/nais/testapp:latest
                     imagePullPolicy: IfNotPresent
                     lifecycle:

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_features_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_features_on_premises.yaml
@@ -117,6 +117,10 @@ tests:
                             value: test-cluster:mynamespace:mynaisjob
                           - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
                             value: "true"
+                          - name: PORT
+                            value: "8080"
+                          - name: BIND_ADDRESS
+                            value: "0.0.0.0:8080"
                         image: navikt/mynaisjob:1.2.3
                         securityContext:
                           runAsUser: 1069

--- a/pkg/resourcecreator/testdata/naisjob/job_features_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/job_features_on_premises.yaml
@@ -116,6 +116,10 @@ tests:
                         value: test-cluster:mynamespace:mynaisjob
                       - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
                         value: "true"
+                      - name: PORT
+                        value: "8080"
+                      - name: BIND_ADDRESS
+                        value: "0.0.0.0:8080"
                     image: navikt/mynaisjob:1.2.3
                     securityContext:
                       runAsUser: 1069

--- a/pkg/resourcecreator/testdata/naisjob/vanilla_cronjob_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/vanilla_cronjob_on_premises.yaml
@@ -115,6 +115,10 @@ tests:
                             value: test-cluster:mynamespace:mynaisjob
                           - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
                             value: "true"
+                          - name: PORT
+                            value: "8080"
+                          - name: BIND_ADDRESS
+                            value: "0.0.0.0:8080"
                         image: navikt/mynaisjob:1.2.3
                         securityContext:
                           runAsUser: 1069

--- a/pkg/resourcecreator/testdata/naisjob/vanilla_job_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/vanilla_job_on_premises.yaml
@@ -112,6 +112,10 @@ tests:
                         value: test-cluster:mynamespace:mynaisjob
                       - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
                         value: "true"
+                      - name: PORT
+                        value: "8080"
+                      - name: BIND_ADDRESS
+                        value: "0.0.0.0:8080"
                     image: navikt/mynaisjob:1.2.3
                     securityContext:
                       runAsUser: 1069

--- a/pkg/resourcecreator/testdata/vanilla.yaml
+++ b/pkg/resourcecreator/testdata/vanilla.yaml
@@ -234,7 +234,8 @@ tests:
             template:
               spec:
                 containers:
-                  - securityContext:
+                  - name: myapplication
+                    securityContext:
                       runAsUser: 1069
                       runAsGroup: 1069
                       allowPrivilegeEscalation: false

--- a/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
@@ -168,6 +168,10 @@ tests:
                         value: test-cluster:mynamespace:myapplication
                       - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
                         value: "true"
+                      - name: PORT
+                        value: "8080"
+                      - name: BIND_ADDRESS
+                        value: "0.0.0.0:8080"
                     resources:
                       limits:
                         memory: 512Mi


### PR DESCRIPTION
PORT defaults to 8080 if not specified, uses `.spec.port` if provided. BIND_ADDRESS defaults to `0.0.0.0:<PORT>`.
If user provides envs directly, these will take precedence