### PR TITLE
feat(poddisruptionbudget): always allow eviction of unhealthy pods

### DIFF
--- a/pkg/resourcecreator/poddisruptionbudget/poddisruptionbudget.go
+++ b/pkg/resourcecreator/poddisruptionbudget/poddisruptionbudget.go
@@ -5,6 +5,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	"github.com/nais/naiserator/pkg/resourcecreator/resource"
 )
@@ -21,8 +22,6 @@ func Create(source Source, ast *resource.Ast) {
 		return
 	}
 
-	maxUnavailable := intstr.FromInt(1)
-
 	podDisruptionBudget := &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -30,12 +29,13 @@ func Create(source Source, ast *resource.Ast) {
 		},
 		ObjectMeta: resource.CreateObjectMeta(source),
 		Spec: policyv1.PodDisruptionBudgetSpec{
-			MaxUnavailable: &maxUnavailable,
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": source.GetName(),
 				},
 			},
+			UnhealthyPodEvictionPolicy: ptr.To(policyv1.AlwaysAllow),
 		},
 	}
 

--- a/pkg/resourcecreator/testdata/vanilla.yaml
+++ b/pkg/resourcecreator/testdata/vanilla.yaml
@@ -209,6 +209,7 @@ tests:
             selector:
               matchLabels:
                 app: myapplication
+            unhealthyPodEvictionPolicy: AlwaysAllow
   - operation: CreateOrUpdate
     apiVersion: apps/v1
     kind: Deployment

--- a/pkg/resourcecreator/testdata/vanilla_legacy_gcp.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_legacy_gcp.yaml
@@ -199,6 +199,7 @@ tests:
             selector:
               matchLabels:
                 app: myapplication
+            unhealthyPodEvictionPolicy: AlwaysAllow
   - operation: CreateOrUpdate
     apiVersion: apps/v1
     kind: Deployment

--- a/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/vanilla_on_premises.yaml
@@ -258,3 +258,4 @@ tests:
             selector:
               matchLabels:
                 app: myapplication
+            unhealthyPodEvictionPolicy: AlwaysAllow


### PR DESCRIPTION
The default behaviour for PDBs only allows eviction of running pods (`status.phase="Running"`) if the application is not disrupted (`.status.currentHealthy` is at least equal to `.status.desiredHealthy`). This means that misbehaving pods (e.g. in CrashLoopBackOff) count towards the budget. In some cases this may indefinitely halt operations such as node drains.

By configuring `unhealthyPodEvictionPolicy` to `AlwaysAllow`, running pods that are not yet healthy may be unconditionally evicted.
This feature has been available in beta since Kubernetes 1.27 and will graduate in 1.31.

See also https://github.com/kubernetes/enhancements/blob/master/keps/sig-apps/3017-pod-healthy-policy-for-pdb/README.md.