### PR TITLE
Allow environment variable referencing

### DIFF
--- a/pkg/resourcecreator/aiven/aiven.go
+++ b/pkg/resourcecreator/aiven/aiven.go
@@ -81,8 +81,10 @@ func Create(source Source, ast *resource.Ast, config Config) error {
 
 	if len(kafkaKeyPaths) > 0 || influxEnabled || openSearchEnabled || redisEnabled {
 		ast.AppendOperation(resource.OperationCreateOrUpdate, &aivenApp)
-		ast.Env = append(ast.Env, makeSecretEnvVar("AIVEN_SECRET_UPDATED", aivenApp.Spec.SecretName))
-		ast.Env = append(ast.Env, makeOptionalSecretEnvVar("AIVEN_CA", aivenApp.Spec.SecretName))
+		ast.Env = append([]v1.EnvVar{
+			makeSecretEnvVar("AIVEN_SECRET_UPDATED", aivenApp.Spec.SecretName),
+			makeOptionalSecretEnvVar("AIVEN_CA", aivenApp.Spec.SecretName),
+		}, ast.Env...)
 	}
 	return nil
 }

--- a/pkg/resourcecreator/aiven/influxdb.go
+++ b/pkg/resourcecreator/aiven/influxdb.go
@@ -32,10 +32,10 @@ func Influx(ast *resource.Ast, influx *nais_io_v1.Influx, aivenApp *aiven_nais_i
 
 func addInfluxEnvVariables(ast *resource.Ast, secretName string) {
 	// Add environment variables for string data
-	ast.Env = append(ast.Env, []corev1.EnvVar{
+	ast.Env = append([]corev1.EnvVar{
 		makeSecretEnvVar("INFLUXDB_USERNAME", secretName),
 		makeSecretEnvVar("INFLUXDB_PASSWORD", secretName),
 		makeSecretEnvVar("INFLUXDB_URI", secretName),
 		makeSecretEnvVar("INFLUXDB_NAME", secretName),
-	}...)
+	}, ast.Env...)
 }

--- a/pkg/resourcecreator/aiven/kafka.go
+++ b/pkg/resourcecreator/aiven/kafka.go
@@ -35,8 +35,8 @@ const (
 )
 
 func addKafkaEnvVariables(ast *resource.Ast, secretName string) {
-	// Add environment variables for string data
-	ast.Env = append(ast.Env, []corev1.EnvVar{
+	ast.Env = append([]corev1.EnvVar{
+		// Add environment variables for string data
 		makeSecretEnvVar(kafkaCertificateKey, secretName),
 		makeSecretEnvVar(kafkaPrivateKeyKey, secretName),
 		makeSecretEnvVar(kafkaBrokersKey, secretName),
@@ -45,10 +45,7 @@ func addKafkaEnvVariables(ast *resource.Ast, secretName string) {
 		makeSecretEnvVar(kafkaSchemaRegistryPasswordKey, secretName),
 		makeSecretEnvVar(kafkaCAKey, secretName),
 		makeSecretEnvVar(kafkaCredStorePasswordKey, secretName),
-	}...)
-
-	// Inject path environment variables to refer to mounted secrets
-	ast.Env = append(ast.Env, []corev1.EnvVar{
+		// Inject path environment variables to refer to mounted secrets
 		{
 			Name:  kafkaCertificatePathKey,
 			Value: filepath.Join(nais_io_v1alpha1.DefaultKafkaratorMountPath, kafkaCertificateFilename),
@@ -69,7 +66,7 @@ func addKafkaEnvVariables(ast *resource.Ast, secretName string) {
 			Name:  kafkaTruststorePathKey,
 			Value: filepath.Join(nais_io_v1alpha1.DefaultKafkaratorMountPath, kafkaTruststoreFilename),
 		},
-	}...)
+	}, ast.Env...)
 }
 
 func createKafkaKeyToPaths() []corev1.KeyToPath {
@@ -109,10 +106,10 @@ func Kafka(source resource.Source, ast *resource.Ast, config Config, naisKafka *
 		if naisKafka.Streams {
 			stream := CreateStream(source, naisKafka)
 			ast.AppendOperation(resource.OperationCreateOrUpdate, stream)
-			ast.Env = append(ast.Env, corev1.EnvVar{
+			ast.Env = append([]corev1.EnvVar{{
 				Name:  "KAFKA_STREAMS_APPLICATION_ID",
 				Value: stream.TopicPrefix(),
-			})
+			}}, ast.Env...)
 		}
 
 		return createKafkaKeyToPaths()

--- a/pkg/resourcecreator/aiven/opensearch.go
+++ b/pkg/resourcecreator/aiven/opensearch.go
@@ -30,9 +30,9 @@ func OpenSearch(ast *resource.Ast, openSearch *nais_io_v1.OpenSearch, aivenApp *
 
 func addOpenSearchEnvVariables(ast *resource.Ast, secretName string) {
 	// Add environment variables for string data
-	ast.Env = append(ast.Env, []corev1.EnvVar{
+	ast.Env = append([]corev1.EnvVar{
 		makeSecretEnvVar("OPEN_SEARCH_USERNAME", secretName),
 		makeSecretEnvVar("OPEN_SEARCH_PASSWORD", secretName),
 		makeSecretEnvVar("OPEN_SEARCH_URI", secretName),
-	}...)
+	}, ast.Env...)
 }

--- a/pkg/resourcecreator/aiven/redis.go
+++ b/pkg/resourcecreator/aiven/redis.go
@@ -67,11 +67,11 @@ func addDefaultRedisIfNotExists(ast *resource.Ast, source Source, aivenProject, 
 func addRedisEnvVariables(ast *resource.Ast, secretName, instanceName string) {
 	// Add environment variables for string data
 	suffix := envVarSuffix(instanceName)
-	ast.Env = append(ast.Env, []corev1.EnvVar{
+	ast.Env = append([]corev1.EnvVar{
 		makeSecretEnvVar(fmt.Sprintf("REDIS_USERNAME_%s", suffix), secretName),
 		makeSecretEnvVar(fmt.Sprintf("REDIS_PASSWORD_%s", suffix), secretName),
 		makeSecretEnvVar(fmt.Sprintf("REDIS_URI_%s", suffix), secretName),
-	}...)
+	}, ast.Env...)
 }
 
 func envVarSuffix(instanceName string) string {

--- a/pkg/resourcecreator/frontend/frontend.go
+++ b/pkg/resourcecreator/frontend/frontend.go
@@ -108,7 +108,7 @@ func Create(source Source, ast *resource.Ast, cfg Config) error {
 	cm := naisJsConfigMap(source, configMapName, naisJsContents)
 
 	ast.AppendOperation(resource.OperationCreateOrUpdate, &cm)
-	ast.Env = append(ast.Env, envVars(cfg.GetFrontendOptions().TelemetryURL)...)
+	ast.Env = append(envVars(cfg.GetFrontendOptions().TelemetryURL), ast.Env...)
 	ast.VolumeMounts = append(ast.VolumeMounts, volumeMount(frontendSpec.GeneratedConfig.MountPath))
 	ast.Volumes = append(ast.Volumes, volume(configMapName))
 

--- a/pkg/resourcecreator/google/gcp/gcp.go
+++ b/pkg/resourcecreator/google/gcp/gcp.go
@@ -42,17 +42,18 @@ func Create(source Source, ast *resource.Ast, cfg Config) error {
 	googleServiceAccount := google_iam.CreateServiceAccount(source, projectID)
 	googleServiceAccountBinding := google_iam.CreatePolicy(source, &googleServiceAccount, projectID)
 
-	// Standard environment variable name in Google SDKs
-	ast.Env = append(ast.Env, v1.EnvVar{
-		Name:  "GOOGLE_CLOUD_PROJECT",
-		Value: teamProjectID,
-	})
-
-	// Legacy environment variable for backwards compability
-	ast.Env = append(ast.Env, v1.EnvVar{
-		Name:  "GCP_TEAM_PROJECT_ID",
-		Value: teamProjectID,
-	})
+	ast.Env = append([]v1.EnvVar{
+		// Standard environment variable name in Google SDKs
+		{
+			Name:  "GOOGLE_CLOUD_PROJECT",
+			Value: teamProjectID,
+		},
+		// Legacy environment variable for backwards compability
+		{
+			Name:  "GCP_TEAM_PROJECT_ID",
+			Value: teamProjectID,
+		},
+	}, ast.Env...)
 
 	ast.AppendOperation(resource.OperationCreateIfNotExists, &googleServiceAccount)
 	ast.AppendOperation(resource.OperationCreateIfNotExists, &googleServiceAccountBinding)

--- a/pkg/resourcecreator/leaderelection/leaderelection.go
+++ b/pkg/resourcecreator/leaderelection/leaderelection.go
@@ -42,7 +42,7 @@ func Create(source Source, ast *resource.Ast, cfg Config) error {
 
 	ast.AppendOperation(resource.OperationCreateOrRecreate, roleBinding(appObjectMeta, roleBindingObjectMeta))
 	ast.Containers = append(ast.Containers, container(source.GetName(), source.GetNamespace(), image))
-	ast.Env = append(ast.Env, electorEnv()...)
+	ast.Env = append(electorEnv(), ast.Env...)
 	return nil
 }
 

--- a/pkg/resourcecreator/proxyopts/proxyopts.go
+++ b/pkg/resourcecreator/proxyopts/proxyopts.go
@@ -91,7 +91,7 @@ func Create(source Source, ast *resource.Ast, cfg Config) error {
 		return fmt.Errorf("generate proxy environment variables: %w", err)
 	}
 
-	ast.Env = append(ast.Env, envs...)
+	ast.Env = append(envs, ast.Env...)
 
 	return nil
 }

--- a/pkg/resourcecreator/testdata/aiven.yaml
+++ b/pkg/resourcecreator/testdata/aiven.yaml
@@ -62,6 +62,17 @@ tests:
                         readOnly: true
                         mountPath: /var/run/secrets/nais.io/kafka
                     env:
+                      - name: AIVEN_SECRET_UPDATED
+                        valueFrom:
+                          secretKeyRef:
+                            key: AIVEN_SECRET_UPDATED
+                            name: ^aiven-myapplication-.{8}-\d{4}-\d\d?$
+                      - name: AIVEN_CA
+                        valueFrom:
+                          secretKeyRef:
+                            key: AIVEN_CA
+                            name: ^aiven-myapplication-.{8}-\d{4}-\d\d?$
+                            optional: true
                       - name: KAFKA_CERTIFICATE
                         valueFrom:
                           secretKeyRef:
@@ -112,14 +123,3 @@ tests:
                         value: /var/run/secrets/nais.io/kafka/client.keystore.p12
                       - name: KAFKA_TRUSTSTORE_PATH
                         value: /var/run/secrets/nais.io/kafka/client.truststore.jks
-                      - name: AIVEN_SECRET_UPDATED
-                        valueFrom:
-                          secretKeyRef:
-                            key: AIVEN_SECRET_UPDATED
-                            name: ^aiven-myapplication-.{8}-\d{4}-\d\d?$
-                      - name: AIVEN_CA
-                        valueFrom:
-                          secretKeyRef:
-                            key: AIVEN_CA
-                            name: ^aiven-myapplication-.{8}-\d{4}-\d\d?$
-                            optional: true


### PR DESCRIPTION
Inadvertant breakage by #561 this restores the posibility for users to reference
(and override) environment variables set by existing resource creators by
setting their environment variables before any user defined environment variables.


Setting the environment variables created by the resource creator allows them to
be referenced and potentially overwritten by any user supplied ones.

```go
ast.Env = append(envs, ast.Env...)
```

Setting the at the end ensures that the user can not override them (but also
disables referencing).


```go
ast.Env = append(ast.Env, envs...)
```
