### PR TITLE
Add random suffix to common name for sqlsslcerts to avoid collision

### DIFF
--- a/pkg/resourcecreator/testdata/gcp_database_shared_vpc.yaml
+++ b/pkg/resourcecreator/testdata/gcp_database_shared_vpc.yaml
@@ -197,7 +197,7 @@ tests:
     kind: SQLSSLCert
     operation: CreateIfNotExists
     match:
-      - type: subset
+      - type: regex
         name: "sql ssl cert"
         resource:
           metadata:
@@ -207,7 +207,7 @@ tests:
               cnrm.cloud.google.com/project-id: team-project-id
               sqeletor.nais.io/secret-name: sqeletor-myinstance-4f09a88b
           spec:
-            commonName: myapplication.test-cluster
+            commonName: myapplication.test-cluster-.{8}
             instanceRef:
               name: myinstance
               namespace: mynamespace

--- a/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_shared_vpc.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/cronjob_gcp_database_shared_vpc.yaml
@@ -164,7 +164,7 @@ tests:
     kind: SQLSSLCert
     operation: CreateIfNotExists
     match:
-      - type: subset
+      - type: regex
         name: "sql ssl cert"
         resource:
           metadata:
@@ -174,7 +174,7 @@ tests:
               cnrm.cloud.google.com/project-id: team-project-id
               sqeletor.nais.io/secret-name: sqeletor-mynaisjob-380f7c17
           spec:
-            commonName: mynaisjob.test-cluster
+            commonName: mynaisjob.test-cluster-.{8}
             instanceRef:
               name: mynaisjob
               namespace: mynamespace


### PR DESCRIPTION
In some situations, a sqlinstance might have existing certs for an application that we don't know about in the cluster. If we try to make new certs with the same common name, it will fail, and the only solution is to use the gcp console to remove the previous cert.

By adding a random suffix, we avoid those collisions, at the cost of some additional certs on the instance that we in probably have lost anyway.