### PR TITLE
fix: en regel per utgående

### DIFF
--- a/pkg/resourcecreator/testdata/accesspolicy_legacy_gcp.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_legacy_gcp.yaml
@@ -132,6 +132,7 @@ tests:
                   - podSelector:
                       matchLabels:
                         app: app3
+              - to:
                   - podSelector:
                       matchLabels:
                         app: app4

--- a/pkg/resourcecreator/testdata/accesspolicy_max.yaml
+++ b/pkg/resourcecreator/testdata/accesspolicy_max.yaml
@@ -95,6 +95,7 @@ tests:
                   - podSelector:
                       matchLabels:
                         app: app3
+              - to:
                   - podSelector:
                       matchLabels:
                         app: app4


### PR DESCRIPTION
Opprinnelig så slo vi sammen alle utgående hosts/ports, som gjorde at man kunne ende opp med en ipBlock-regel ble slått sammen med en namespace-regel.

nais.yaml:

```yaml
  accessPolicy:
    outbound:
      external:
        - host: test.maskinporten.no
        - host: io.fiks.test.ks.no
          ports:
            - port: 5671
        - ipv4: 34.88.234.148
          ports:
            - port: 5432
            - port: 3307
      rules:
        - application: barn-bvr-api
          namespace: barnevern
```

Output (netpol):

```yaml
  egress:
    - to:
        - namespaceSelector: {}
          podSelector:
            matchLabels:
              k8s-app: kube-dns
    - to:
        - ipBlock:
            cidr: 10.12.0.0/24
    - ports:
        - port: 5432
          protocol: TCP
        - port: 3307
          protocol: TCP
      to:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: barnevern
          podSelector:
            matchLabels:
              app: barn-bvr-api
        - ipBlock:
            cidr: 34.88.234.148/32
```

Her ser vi hvordan ting klumper seg sammen. Så derfor lager vi heller en `egress.to` per regel vi har i nais.yaml

Så da vil vi ende opp med:

```yaml
  egress:
    - to:
        - namespaceSelector: {}
          podSelector:
            matchLabels:
              k8s-app: kube-dns
    - to:
        - ipBlock:
            cidr: 10.12.0.0/24
    - ports:
        - port: 5432
          protocol: TCP
        - port: 3307
          protocol: TCP
      to:
        - ipBlock:
            cidr: 34.88.234.148/32
    - to:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: barnevern
          podSelector:
            matchLabels:
              app: barn-bvr-api
```