### PR TITLE
Ensure GOOGLE_CLOUD_PROJECT is set whenever applicable

### DIFF
--- a/pkg/resourcecreator/google/gcp/gcp.go
+++ b/pkg/resourcecreator/google/gcp/gcp.go
@@ -36,7 +36,6 @@ func Create(source Source, ast *resource.Ast, cfg Config) error {
 	}
 
 	projectID := cfg.GetGoogleProjectID()
-	teamProjectID := cfg.GetGoogleTeamProjectID()
 
 	googleServiceAccount := google_iam.CreateServiceAccount(source, projectID)
 	googleServiceAccountBinding := google_iam.CreatePolicy(source, &googleServiceAccount, projectID)

--- a/pkg/resourcecreator/google/gcp/gcp.go
+++ b/pkg/resourcecreator/google/gcp/gcp.go
@@ -9,7 +9,6 @@ import (
 	google_sql "github.com/nais/naiserator/pkg/resourcecreator/google/sql"
 	google_storagebucket "github.com/nais/naiserator/pkg/resourcecreator/google/storagebucket"
 	"github.com/nais/naiserator/pkg/resourcecreator/resource"
-	v1 "k8s.io/api/core/v1"
 )
 
 type Config interface {
@@ -41,19 +40,6 @@ func Create(source Source, ast *resource.Ast, cfg Config) error {
 
 	googleServiceAccount := google_iam.CreateServiceAccount(source, projectID)
 	googleServiceAccountBinding := google_iam.CreatePolicy(source, &googleServiceAccount, projectID)
-
-	ast.PrependEnv([]v1.EnvVar{
-		// Standard environment variable name in Google SDKs
-		{
-			Name:  "GOOGLE_CLOUD_PROJECT",
-			Value: teamProjectID,
-		},
-		// Legacy environment variable for backwards compability
-		{
-			Name:  "GCP_TEAM_PROJECT_ID",
-			Value: teamProjectID,
-		},
-	}...)
 
 	ast.AppendOperation(resource.OperationCreateIfNotExists, &googleServiceAccount)
 	ast.AppendOperation(resource.OperationCreateIfNotExists, &googleServiceAccountBinding)


### PR DESCRIPTION
The new team logs needs to know the Google Cloud Project ID for the team in order to send the logs to the right Cloud Logging instance.

Co-authored-by: Terje Sannum <terje.sannum@nav.no>
