### PR TITLE
Delete postgres resources when an application is deleted

### DIFF
--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -190,6 +190,8 @@ func TestSynchronizer(t *testing.T) {
 	listers := naiserator_scheme.GenericListers()
 	listers = append(listers, naiserator_scheme.GCPListers()...)
 	listers = append(listers, naiserator_scheme.AivenListers()...)
+	// DO NOT ADD! Adding the AcidZalandoListers here breaks the test due to some inconsistencies in how envtest responds to requests
+	// listers = append(listers, naiserator_scheme.AcidZalandoListers()...)
 	for _, list := range listers {
 		err = rig.client.List(ctx, list)
 		assert.NoError(t, err, "Unable to list resource, are the CRDs installed?")


### PR DESCRIPTION
This cleans up the Postgresql and NetworkPolicies created for the app in the postgres namespace.
The IAMPolicy that gets created is shared between all applications in the same namespace, so that can not be deleted.

I attempted to extend TestSynchronizer to test this, but adding the AcidZalandoListers makes the test fail because the responses from the envtest fake api-server seem to trigger incorrect lookups when controller-runtime attempts to identify the correct GVK->Type mapping. This is caused by Zalando using `postgresql` instead of `Postgresql` and controller-runtime making assumptions all over the place. For some reason it works when running with a real cluster, presumably other assumptions works better :shrug: 
