### PR TITLE
fix filesFrom duplicate volume names when secret and configmap share …

### DIFF
--- a/pkg/resourcecreator/deployment/deployment_test.go
+++ b/pkg/resourcecreator/deployment/deployment_test.go
@@ -100,7 +100,7 @@ func TestDeployment(t *testing.T) {
 
 		appContainer := ast.Containers[0]
 		assert.NotNil(t, appContainer)
-		assert.Equal(t, nais_io_v1alpha1.DefaultSecretMountPath, test.GetVolumeMountByName(appContainer.VolumeMounts, "foo").MountPath)
-		assert.Equal(t, customMountPath, test.GetVolumeMountByName(appContainer.VolumeMounts, "bar").MountPath)
+		assert.Equal(t, nais_io_v1alpha1.DefaultSecretMountPath, test.GetVolumeMountByName(appContainer.VolumeMounts, "secret-1").MountPath)
+		assert.Equal(t, customMountPath, test.GetVolumeMountByName(appContainer.VolumeMounts, "secret-2").MountPath)
 	})
 }

--- a/pkg/resourcecreator/pod/pod.go
+++ b/pkg/resourcecreator/pod/pod.go
@@ -225,35 +225,45 @@ func generateNameFromMountPath(mountPath string) string {
 }
 
 func filesFrom(ast *resource.Ast, naisFilesFrom []nais_io_v1.FilesFrom) {
+	names := make(map[string]int)
+	uniqueName := func(name string) string {
+		count := names[name]
+		names[name]++
+		if count > 0 {
+			return fmt.Sprintf("%s-%d", name, count+1)
+		}
+		return name
+	}
+
 	for _, file := range naisFilesFrom {
 		if len(file.ConfigMap) > 0 {
-			name := file.ConfigMap
-			ast.Volumes = append(ast.Volumes, fromFilesConfigmapVolume(name))
+			name := uniqueName(file.ConfigMap)
+			ast.Volumes = append(ast.Volumes, fromFilesConfigmapVolume(name, file.ConfigMap))
 			ast.VolumeMounts = append(ast.VolumeMounts,
 				FromFilesVolumeMount(name, file.MountPath, nais_io_v1alpha1.GetDefaultMountPath(name), true))
 		} else if len(file.Secret) > 0 {
-			name := file.Secret
-			ast.Volumes = append(ast.Volumes, FromFilesSecretVolume(name, name, nil))
+			name := uniqueName(file.Secret)
+			ast.Volumes = append(ast.Volumes, FromFilesSecretVolume(name, file.Secret, nil))
 			ast.VolumeMounts = append(ast.VolumeMounts, FromFilesVolumeMount(name, file.MountPath, nais_io_v1alpha1.DefaultSecretMountPath, true))
 		} else if len(file.PersistentVolumeClaim) > 0 {
-			name := file.PersistentVolumeClaim
-			ast.Volumes = append(ast.Volumes, FromFilesPVCVolume(name, name))
+			name := uniqueName(file.PersistentVolumeClaim)
+			ast.Volumes = append(ast.Volumes, FromFilesPVCVolume(name, file.PersistentVolumeClaim))
 			ast.VolumeMounts = append(ast.VolumeMounts, FromFilesVolumeMount(name, file.MountPath, nais_io_v1alpha1.GetDefaultPVCMountPath(name), false))
 		} else if file.EmptyDir != nil && len(file.MountPath) > 0 {
-			name := generateNameFromMountPath(file.MountPath)
+			name := uniqueName(generateNameFromMountPath(file.MountPath))
 			ast.Volumes = append(ast.Volumes, FilesFromEmptyDir(name, file.EmptyDir.Medium))
 			ast.VolumeMounts = append(ast.VolumeMounts, FromFilesVolumeMount(name, file.MountPath, file.MountPath, false))
 		}
 	}
 }
 
-func fromFilesConfigmapVolume(name string) corev1.Volume {
+func fromFilesConfigmapVolume(volumeName, configMapName string) corev1.Volume {
 	return corev1.Volume{
-		Name: name,
+		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: name,
+					Name: configMapName,
 				},
 			},
 		},

--- a/pkg/resourcecreator/pod/pod.go
+++ b/pkg/resourcecreator/pod/pod.go
@@ -225,32 +225,31 @@ func generateNameFromMountPath(mountPath string) string {
 }
 
 func filesFrom(ast *resource.Ast, naisFilesFrom []nais_io_v1.FilesFrom) {
-	names := make(map[string]int)
-	uniqueName := func(name string) string {
-		count := names[name]
-		names[name]++
-		if count > 0 {
-			return fmt.Sprintf("%s-%d", name, count+1)
-		}
-		return name
-	}
+	configs := 0
+	secrets := 0
+	persistence := 0
+	emptyDirs := 0
 
 	for _, file := range naisFilesFrom {
 		if len(file.ConfigMap) > 0 {
-			name := uniqueName(file.ConfigMap)
+			configs++
+			name := fmt.Sprintf("config-%d", configs)
 			ast.Volumes = append(ast.Volumes, fromFilesConfigmapVolume(name, file.ConfigMap))
 			ast.VolumeMounts = append(ast.VolumeMounts,
-				FromFilesVolumeMount(name, file.MountPath, nais_io_v1alpha1.GetDefaultMountPath(name), true))
+				FromFilesVolumeMount(name, file.MountPath, nais_io_v1alpha1.GetDefaultMountPath(file.ConfigMap), true))
 		} else if len(file.Secret) > 0 {
-			name := uniqueName(file.Secret)
+			secrets++
+			name := fmt.Sprintf("secret-%d", secrets)
 			ast.Volumes = append(ast.Volumes, FromFilesSecretVolume(name, file.Secret, nil))
 			ast.VolumeMounts = append(ast.VolumeMounts, FromFilesVolumeMount(name, file.MountPath, nais_io_v1alpha1.DefaultSecretMountPath, true))
 		} else if len(file.PersistentVolumeClaim) > 0 {
-			name := uniqueName(file.PersistentVolumeClaim)
+			persistence++
+			name := fmt.Sprintf("pvc-%d", persistence)
 			ast.Volumes = append(ast.Volumes, FromFilesPVCVolume(name, file.PersistentVolumeClaim))
-			ast.VolumeMounts = append(ast.VolumeMounts, FromFilesVolumeMount(name, file.MountPath, nais_io_v1alpha1.GetDefaultPVCMountPath(name), false))
+			ast.VolumeMounts = append(ast.VolumeMounts, FromFilesVolumeMount(name, file.MountPath, nais_io_v1alpha1.GetDefaultPVCMountPath(file.PersistentVolumeClaim), false))
 		} else if file.EmptyDir != nil && len(file.MountPath) > 0 {
-			name := uniqueName(generateNameFromMountPath(file.MountPath))
+			emptyDirs++
+			name := fmt.Sprintf("emptydir-%d", emptyDirs)
 			ast.Volumes = append(ast.Volumes, FilesFromEmptyDir(name, file.EmptyDir.Medium))
 			ast.VolumeMounts = append(ast.VolumeMounts, FromFilesVolumeMount(name, file.MountPath, file.MountPath, false))
 		}

--- a/pkg/resourcecreator/testdata/filesfrom.yaml
+++ b/pkg/resourcecreator/testdata/filesfrom.yaml
@@ -32,35 +32,35 @@ tests:
             template:
               spec:
                 volumes:
-                  - name: mycm
+                  - name: config-1
                     configMap:
                       name: mycm
-                  - name: mysecret
+                  - name: secret-1
                     secret:
                       secretName: mysecret
-                  - name: pvc-name
+                  - name: pvc-1
                     persistentVolumeClaim:
                       claimName: pvc-name
                   - emptyDir:
                       medium: Memory
-                    name: var-cache-memory
+                    name: emptydir-1
                   - emptyDir: {}
-                    name: var-cache-disk
+                    name: emptydir-2
                 securityContext:
                   fsGroup: 1069
                   fsGroupChangePolicy: "OnRootMismatch"
                 containers:
                   - name: myapplication
                     volumeMounts:
-                      - name: mycm
+                      - name: config-1
                         readOnly: true
                         mountPath: /var/run/configmaps/mycm
-                      - name: mysecret
+                      - name: secret-1
                         readOnly: true
                         mountPath: /var/run/secrets
-                      - name: pvc-name
+                      - name: pvc-1
                         mountPath: /var/run/pvc/pvc-name
                       - mountPath: /var/cache/memory
-                        name: var-cache-memory
+                        name: emptydir-1
                       - mountPath: /var/cache/disk
-                        name: var-cache-disk
+                        name: emptydir-2

--- a/pkg/resourcecreator/testdata/filesfrom_duplicate_names.yaml
+++ b/pkg/resourcecreator/testdata/filesfrom_duplicate_names.yaml
@@ -1,0 +1,47 @@
+testconfig:
+  description: filesFrom with duplicate secret and configmap names
+config:
+  features: {}
+input:
+  kind: Application
+  apiVersion: nais.io/v1alpha1
+  metadata:
+    name: myapplication
+    namespace: mynamespace
+  spec:
+    filesFrom:
+      - secret: myapplication
+        mountPath: /var/run/secrets/nais.io/app
+      - configmap: myapplication
+        mountPath: /var/run/config/nais.io/app
+tests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: myapplication
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: unique volume names for same-named secret and configmap
+        resource:
+          spec:
+            template:
+              spec:
+                volumes:
+                  - name: myapplication
+                    secret:
+                      secretName: myapplication
+                  - name: myapplication-2
+                    configMap:
+                      name: myapplication
+                securityContext:
+                  fsGroup: 1069
+                  fsGroupChangePolicy: "OnRootMismatch"
+                containers:
+                  - name: myapplication
+                    volumeMounts:
+                      - name: myapplication
+                        readOnly: true
+                        mountPath: /var/run/secrets/nais.io/app
+                      - name: myapplication-2
+                        readOnly: true
+                        mountPath: /var/run/config/nais.io/app

--- a/pkg/resourcecreator/testdata/filesfrom_duplicate_names.yaml
+++ b/pkg/resourcecreator/testdata/filesfrom_duplicate_names.yaml
@@ -27,10 +27,10 @@ tests:
             template:
               spec:
                 volumes:
-                  - name: myapplication
+                  - name: secret-1
                     secret:
                       secretName: myapplication
-                  - name: myapplication-2
+                  - name: config-1
                     configMap:
                       name: myapplication
                 securityContext:
@@ -39,9 +39,9 @@ tests:
                 containers:
                   - name: myapplication
                     volumeMounts:
-                      - name: myapplication
+                      - name: secret-1
                         readOnly: true
                         mountPath: /var/run/secrets/nais.io/app
-                      - name: myapplication-2
+                      - name: config-1
                         readOnly: true
                         mountPath: /var/run/config/nais.io/app

--- a/pkg/resourcecreator/testdata/naisjob/env_files_from.yaml
+++ b/pkg/resourcecreator/testdata/naisjob/env_files_from.yaml
@@ -38,10 +38,10 @@ tests:
                 template:
                   spec:
                     volumes:
-                      - name: mycm
+                      - name: config-1
                         configMap:
                           name: mycm
-                      - name: mysecret
+                      - name: secret-1
                         secret:
                           secretName: mysecret
                     containers:
@@ -59,9 +59,9 @@ tests:
                           - secretRef:
                               name: mysecret
                         volumeMounts:
-                          - name: mycm
+                          - name: config-1
                             readOnly: true
                             mountPath: /var/run/configmaps/mycm
-                          - name: mysecret
+                          - name: secret-1
                             readOnly: true
                             mountPath: /var/run/secrets


### PR DESCRIPTION
…the same name

When filesFrom entries reference a secret and a configmap with the same name, the generated pod spec would have two volumes with identical names, failing to mount correctly.

Add golden file test for the duplicate name scenario.