### PR TITLE
feat(ingress): migrate nginx annotation `proxy_set_header` to `HAProxy`

### DIFF
--- a/pkg/resourcecreator/ingress/ingress.go
+++ b/pkg/resourcecreator/ingress/ingress.go
@@ -97,6 +97,12 @@ func copyHAProxyAnnotations(dst, src map[string]string) {
 				continue
 			}
 		}
+		if k == "haproxy.org/request-set-header" {
+			if existing := dst[k]; existing != "" {
+				dst[k] = fmt.Sprintf("%s\n%s", v, existing)
+				continue
+			}
+		}
 		dst[k] = v
 	}
 }
@@ -133,6 +139,7 @@ func migrateNginxAnnotationsToHAProxyAnnotations(haProxy, nginx map[string]strin
 
 	migrateRewriteTarget(haProxy, nginxAnnotations)
 	migrateWhitelistSourceRange(haProxy, nginxAnnotations)
+	migrateConfigurationSnippet(haProxy, nginxAnnotations)
 }
 
 var (
@@ -205,6 +212,63 @@ func migrateWhitelistSourceRange(annotations, nginxAnnotations map[string]string
 		return
 	}
 	annotations[haproxyBackendConfigAnnotation] = snippet
+}
+
+func migrateConfigurationSnippet(annotations, nginxAnnotations map[string]string) {
+	snippet := nginxAnnotations["nginx.ingress.kubernetes.io/configuration-snippet"]
+	if snippet == "" {
+		return
+	}
+
+	var setHeaders []string
+	for line := range strings.SplitSeq(snippet, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "proxy_set_header ") || !strings.HasSuffix(line, ";") {
+			continue
+		}
+
+		// We expect `proxy_set_header <header name> <header value>` syntax
+		inner := strings.TrimSpace(line[len("proxy_set_header ") : len(line)-1])
+		parts := strings.Fields(inner) // Used only to verify that both fields exist.
+		if len(parts) < 2 {
+			continue
+		}
+
+		// Parse `<header value>` to see if it's something we support automatically mapping
+		targetHeader := parts[0]
+		value := strings.TrimSpace(inner[len(targetHeader):])
+		headerValue := strings.Trim(value, `"'`)
+		if headerValue == "" {
+			continue
+		}
+
+		valueHeaderName, isHTTPHeaderVariable := strings.CutPrefix(headerValue, "$http_")
+		if !isHTTPHeaderVariable && strings.Contains(headerValue, "$") { // -> It's another nginx variable, we don't handle those
+			continue
+		}
+
+		haproxyValue := headerValue
+		if isHTTPHeaderVariable {
+			if strings.Contains(valueHeaderName, "$") { // -> It's another nginx variable, we don't handle those
+				continue
+			}
+			// At this point we assume it's safe to interpret it as described for `$http_` here:
+			// https://nginx.org/en/docs/http/ngx_http_core_module.html#variables
+			srcHeader := strings.ReplaceAll(valueHeaderName, "_", "-")
+			haproxyValue = fmt.Sprintf("%%[req.fhdr(%s)]", srcHeader)
+		}
+
+		setHeaders = append(setHeaders, fmt.Sprintf("%s %s", targetHeader, haproxyValue))
+	}
+
+	if len(setHeaders) == 0 {
+		return
+	}
+
+	if existing := annotations["haproxy.org/request-set-header"]; existing != "" {
+		setHeaders = append(setHeaders, existing)
+	}
+	annotations["haproxy.org/request-set-header"] = strings.Join(setHeaders, "\n")
 }
 
 // nginxToHAProxyCaptureGroups converts $1, $2 to \1, \2

--- a/pkg/resourcecreator/testdata/ingress_haproxy_migrate_nginx_configuration-snippet_proxy_set_header.yaml
+++ b/pkg/resourcecreator/testdata/ingress_haproxy_migrate_nginx_configuration-snippet_proxy_set_header.yaml
@@ -1,0 +1,39 @@
+testconfig:
+  description: ingress haproxy migration handles configuration-snippet proxy_set_header
+config:
+  features:
+    haproxy: true
+  domain-ingressclass-mapping:
+    - domainSuffix: .bar
+      ingressClass: very-haproxy
+input:
+  kind: Application
+  apiVersion: nais.io/v1alpha1
+  metadata:
+    name: myapplication
+    annotations:
+      haproxy.org/request-set-header: "Existing-Header existing-value"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        proxy_set_header X-ProxyUser-IP $http_x_client_ip;
+        proxy_set_header X-Empty "";
+        proxy_set_header X-Unknown $remote_addr;
+        proxy_set_header X-Static "static-value";
+        more_set_headers "Cache-Control: public,max-age=0";
+  spec:
+    ingresses:
+      - https://foo.bar/baz
+tests:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    name: myapplication-very-haproxy-efe42262
+    operation: CreateOrUpdate
+    match:
+      - type: subset
+        name: "ingress created with correct annotations"
+        resource:
+          metadata:
+            annotations:
+              haproxy.org/request-set-header: |-
+                Existing-Header existing-value
+                X-ProxyUser-IP %[req.fhdr(x-client-ip)]
+                X-Static static-value


### PR DESCRIPTION
This preserves request-header behavior for applications relying on `nginx.ingress.kubernetes.io/configuration-snippet` during ingress migration.

```
HAProxy header names are case-insensitive, including the req.fhdr(...) lookup we use.
Sources:
- HAProxy docs, HTTP request headers:
  https://docs.haproxy.org/2.8/configuration.html#1.2.2

Quote:
> Contrary to a common misconception, header names are not case-sensitive

Also:
> Internally, all header names are normalized to lower case so that HTTP/1.x and HTTP/2 use the exact same representation
- HAProxy docs, hdr(<name>):
  https://docs.haproxy.org/2.8/configuration.html#4.2-balance

Quote:
> the header name in parenthesis is not case sensitive
- HAProxy source confirms req.fhdr(...) uses http_get_htx_fhdr(...), which calls http_find_header(...).
- http_find_header(...) uses isteqi(n, name) for exact header-name matching.
- isteqi(...) is HAProxy’s case-insensitive string equality function.

Conclusion:
- %[req.fhdr(x-client-ip)]
- %[req.fhdr(X-Client-IP)]
- %[req.fhdr(X-CLIENT-IP)]
all target the same request header name in HAProxy.
```
