### PR TITLE
fix(ingress): avoid cluster-wide `HAProxy` rate-limit log spam

### DIFF
--- a/pkg/resourcecreator/ingress/ingress.go
+++ b/pkg/resourcecreator/ingress/ingress.go
@@ -115,7 +115,6 @@ func migrateNginxAnnotationsToHAProxyAnnotations(haProxy, nginx map[string]strin
 		"proxy-read-timeout":    "timeout-server",
 		"proxy-send-timeout":    "timeout-client",
 		"upstream-vhost":        "set-host",
-		"limit-rpm":             "rate-limit-request",
 	}
 
 	for key, value := range nginxAnnotations {
@@ -131,6 +130,7 @@ func migrateNginxAnnotationsToHAProxyAnnotations(haProxy, nginx map[string]strin
 		}
 	}
 
+	migrateLimitRpm(haProxy, nginxAnnotations)
 	migrateRewriteTarget(haProxy, nginxAnnotations)
 	migrateWhitelistSourceRange(haProxy, nginxAnnotations)
 }
@@ -139,6 +139,17 @@ var (
 	nginxCaptureGroupRegex = regexp.MustCompile(`\$(\d+)`)
 	nginxArgVariableRegex  = regexp.MustCompile(`\$arg_(\w+)`)
 )
+
+func migrateLimitRpm(annotations, nginxAnnotations map[string]string) {
+	limitRpm := nginxAnnotations["nginx.ingress.kubernetes.io/limit-rpm"]
+	if limitRpm == "" {
+		return
+	}
+
+	annotations["haproxy.org/rate-limit-period"] = "1m"
+	annotations["haproxy.org/rate-limit-request"] = fmt.Sprint(limitRpm)
+	annotations["haproxy.org/rate-limit-status-code"] = "429"
+}
 
 // migrateRewriteTarget translates an nginx rewrite-target annotation to equivalent HAProxy annotation(s)
 func migrateRewriteTarget(annotations, nginxAnnotations map[string]string) {

--- a/pkg/resourcecreator/testdata/ingress_haproxy_migrate_empty_strings.yaml
+++ b/pkg/resourcecreator/testdata/ingress_haproxy_migrate_empty_strings.yaml
@@ -38,7 +38,6 @@ tests:
         resource:
           metadata:
             annotations:
-              haproxy.org/rate-limit-request: ""
               nais.io/deploymentCorrelationID: ""
               prometheus.io/path: ""
               prometheus.io/scrape: "true"

--- a/pkg/resourcecreator/testdata/ingress_haproxy_migrate_limit_rpm.yaml
+++ b/pkg/resourcecreator/testdata/ingress_haproxy_migrate_limit_rpm.yaml
@@ -27,4 +27,6 @@ tests:
         resource:
           metadata:
             annotations:
+              haproxy.org/rate-limit-period: "1m"
               haproxy.org/rate-limit-request: "500"
+              haproxy.org/rate-limit-status-code: "429"


### PR DESCRIPTION
Migrated `nginx.ingress.kubernetes.io/limit-rpm` ingresses carry their `HAProxy` rate-limit policy locally so `github:nais/helm-charts` does not need noisy cluster-wide defaults.

Co-Authored-By: @muni10 <sten.ivar.rokke@nav.no>
