### PR TITLE
fix(ingress): only scrape ingress if liveness path is set

### DIFF
--- a/pkg/resourcecreator/ingress/ingress.go
+++ b/pkg/resourcecreator/ingress/ingress.go
@@ -100,8 +100,12 @@ func createIngressBase(source Source, ingressClass string) (*networkingv1.Ingres
 
 	objectMeta := resource.CreateObjectMeta(source)
 	objectMeta.Name = shortName
-	objectMeta.Annotations["prometheus.io/scrape"] = "true"
-	objectMeta.Annotations["prometheus.io/path"] = source.GetLiveness().Path
+
+	liveness := source.GetLiveness()
+	if liveness != nil && liveness.Path != "" {
+		objectMeta.Annotations["prometheus.io/scrape"] = "true"
+		objectMeta.Annotations["prometheus.io/path"] = liveness.Path
+	}
 
 	return &networkingv1.Ingress{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/resourcecreator/testdata/ingress_haproxy_migrate_empty_strings.yaml
+++ b/pkg/resourcecreator/testdata/ingress_haproxy_migrate_empty_strings.yaml
@@ -39,5 +39,3 @@ tests:
           metadata:
             annotations:
               nais.io/deploymentCorrelationID: ""
-              prometheus.io/path: ""
-              prometheus.io/scrape: "true"

--- a/pkg/resourcecreator/testdata/ingress_on_premises.yaml
+++ b/pkg/resourcecreator/testdata/ingress_on_premises.yaml
@@ -35,8 +35,6 @@ tests:
               nais.io/deploymentCorrelationID: ""
               nginx.ingress.kubernetes.io/backend-protocol: HTTP
               nginx.ingress.kubernetes.io/use-regex: "true"
-              prometheus.io/path: ""
-              prometheus.io/scrape: "true"
           spec:
             ingressClassName: very-nginx
             rules:

--- a/pkg/resourcecreator/testdata/ingress_probe.yaml
+++ b/pkg/resourcecreator/testdata/ingress_probe.yaml
@@ -1,5 +1,5 @@
 testconfig:
-  description: ingress resource is created on-premises
+  description: application with liveness path results in ingress resource with prometheus annotations
 config:
   features:
     haproxy: true
@@ -13,14 +13,11 @@ input:
     name: myapplication
     namespace: mynamespace
     uid: "123456"
-    annotations:
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "100"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "101"
-      nginx.ingress.kubernetes.io/proxy-connect-timeout: "102"
-      nginx.ingress.kubernetes.io/rewrite-target: "some"
   spec:
     ingresses:
       - https://foo.bar/baz
+    liveness:
+      path: "liveness"
 tests:
   - apiVersion: networking.k8s.io/v1
     kind: Ingress
@@ -40,10 +37,8 @@ tests:
           metadata:
             annotations:
               nais.io/deploymentCorrelationID: ""
-              haproxy.org/timeout-server: "100s"
-              haproxy.org/timeout-client: "101s"
-              haproxy.org/timeout-connect: "102s"
-              haproxy.org/path-rewrite: "some"
+              prometheus.io/path: "liveness"
+              prometheus.io/scrape: "true"
           spec:
             ingressClassName: very-haproxy
             rules:


### PR DESCRIPTION
This otherwise defaults to the root path, which may require authentication (i.e. results in a HTTP 3xx/4xx).