### PR TITLE
fix(synchronizer): reconcile deployments with new correlation IDs

### DIFF
--- a/pkg/synchronizer/monitoring.go
+++ b/pkg/synchronizer/monitoring.go
@@ -22,7 +22,6 @@ import (
 const (
 	RolloutMessageCompleted        = "Rollout has completed"
 	RolloutMessageCronJobCompleted = "No support for monitoring CronJobs"
-	RolloutMessageNoop             = "No changes; deployment already up to date"
 )
 
 var rolloutMonitorLock sync.Mutex

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -238,18 +238,9 @@ func (n *Synchronizer) Reconcile(ctx context.Context, req ctrl.Request, app reso
 		changed = false
 		logger.Debugf("Synchronization hash not changed; skipping synchronization")
 
-		switch app.GetStatus().SynchronizationState {
-		case events.Synchronized:
-			// Application is not rolled out completely; start monitoring
+		// Application is not rolled out completely; start monitoring
+		if app.GetStatus().SynchronizationState == events.Synchronized {
 			n.MonitorRollout(app, logger)
-		case events.RolloutComplete:
-			// Re-deploy with no spec changes; immediately signal completion with the
-			// current correlationID so deployd doesn't time out waiting for an event
-			// that would never come.
-			_, err = n.reportEvent(ctx, resource.CreateEvent(app, events.RolloutComplete, RolloutMessageNoop, "Normal"))
-			if err != nil {
-				log.Errorf("While creating a noop rollout event, an error occurred: %s", err)
-			}
 		}
 
 		return ctrl.Result{}, nil
@@ -505,7 +496,9 @@ func (n *Synchronizer) Prepare(ctx context.Context, source resource.Source) (*Ro
 	}
 
 	// Skip processing if application didn't change since last synchronization.
-	if !imageHasChanged(wantedImage, imageSource) && source.GetStatus().SynchronizationHash == rollout.SynchronizationHash {
+	if !imageHasChanged(wantedImage, imageSource) &&
+		source.GetStatus().SynchronizationHash == rollout.SynchronizationHash &&
+		(source.CorrelationID() == "" || source.GetStatus().CorrelationID == source.CorrelationID()) {
 		return nil, nil
 	}
 

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -245,6 +245,21 @@ func TestSynchronizer(t *testing.T) {
 			assert.Equal(t, fixtures.OtherApplicationImage, app.Status.EffectiveImage)
 		})
 	})
+
+	t.Run("Redeploy With New Correlation ID", func(t *testing.T) {
+		app := fixtures.MinimalApplication(
+			fixtures.WithName("correlation-redeploy"),
+			fixtures.WithAnnotation(nais_io.DeploymentCorrelationIDAnnotation, "deploy-id"),
+		)
+		testRedeployWithNewCorrelationID(t, rig, ctx, app)
+	})
+
+	t.Run("Manual Deployment Without Correlation ID", func(t *testing.T) {
+		app := fixtures.MinimalApplication(
+			fixtures.WithName("manual-deployment"),
+		)
+		testManualDeploymentWithoutCorrelationID(t, rig, ctx, app)
+	})
 }
 
 func testAppDeployment(t *testing.T, rig *testRig, ctx context.Context, app *nais_io_v1alpha1.Application, cfg config.Config) {
@@ -441,6 +456,85 @@ func testDeleteCorrectIAMResources(t *testing.T, rig *testRig, ctx context.Conte
 	assert.NoError(t, err)
 	assert.Len(t, iam_service_accounts.Items, 1)
 	assert.Equal(t, app.GetName(), iam_service_accounts.Items[0].Labels["app"])
+}
+
+func testRedeployWithNewCorrelationID(t *testing.T, rig *testRig, ctx context.Context, app *nais_io_v1alpha1.Application) {
+	app.Labels = map[string]string{"team": app.Namespace}
+	objectKey := client.ObjectKeyFromObject(app)
+	req := ctrl.Request{NamespacedName: objectKey}
+
+	require.NoError(t, rig.client.Create(ctx, app))
+
+	// Reconcile to set finalizer
+	result, err := rig.synchronizer.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Reconcile to synchronize
+	result, err = rig.synchronizer.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	newCorrelationID := "new-deploy-id"
+	existingApp := &nais_io_v1alpha1.Application{}
+	require.NoError(t, rig.client.Get(ctx, objectKey, existingApp))
+	existingSyncHash := existingApp.GetStatus().SynchronizationHash
+
+	// Simulate new deployment request with no other changes
+	existingApp.Annotations[nais_io.DeploymentCorrelationIDAnnotation] = newCorrelationID
+	require.NoError(t, rig.client.Update(ctx, existingApp))
+
+	// Reconcile the new deployment and assert that processing is not skipped.
+	result, err = rig.synchronizer.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	rig.testResource(t, ctx, &nais_io_v1alpha1.Application{}, objectKey, func(t *testing.T, resource client.Object) {
+		redeployedApp := resource.(*nais_io_v1alpha1.Application)
+		assert.Equal(t, existingSyncHash, redeployedApp.Status.SynchronizationHash)
+		assert.Equal(t, newCorrelationID, redeployedApp.Status.CorrelationID)
+	})
+	rig.testResource(t, ctx, &appsv1.Deployment{}, objectKey, func(t *testing.T, resource client.Object) {
+		deployment := resource.(*appsv1.Deployment)
+		assert.Equal(t, newCorrelationID, deployment.Annotations[nais_io.DeploymentCorrelationIDAnnotation])
+	})
+}
+
+func testManualDeploymentWithoutCorrelationID(t *testing.T, rig *testRig, ctx context.Context, app *nais_io_v1alpha1.Application) {
+	app.Labels = map[string]string{"team": app.Namespace}
+	objectKey := client.ObjectKeyFromObject(app)
+	req := ctrl.Request{NamespacedName: objectKey}
+
+	require.NoError(t, rig.client.Create(ctx, app))
+
+	// Reconcile to set finalizer
+	result, err := rig.synchronizer.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Reconcile to synchronize
+	result, err = rig.synchronizer.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	existingApp := &nais_io_v1alpha1.Application{}
+	require.NoError(t, rig.client.Get(ctx, objectKey, existingApp))
+	existingSyncHash := existingApp.Status.SynchronizationHash
+	existingCorrelationID := existingApp.Status.CorrelationID
+	require.NotEmpty(t, existingCorrelationID)
+	assert.Empty(t, existingApp.CorrelationID())
+
+	// Reconcile the unchanged manual deployment and assert that processing is skipped.
+	result, err = rig.synchronizer.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	rig.testResource(t, ctx, &nais_io_v1alpha1.Application{}, objectKey, func(t *testing.T, resource client.Object) {
+		reconciledApp := resource.(*nais_io_v1alpha1.Application)
+		assert.Equal(t, existingSyncHash, reconciledApp.Status.SynchronizationHash)
+		assert.Equal(t, existingCorrelationID, reconciledApp.Status.CorrelationID)
+		assert.Empty(t, reconciledApp.CorrelationID())
+	})
 }
 
 func TestSynchronizerResourceOptions(t *testing.T) {


### PR DESCRIPTION
Status subresources (introduced in liberator [bacd0593](https://github.com/nais/liberator/commit/bacd0593)) now preserve synchronization status when deployd updates a resource. This caused unchanged redeployments to be no-ops.

Include deployd's new correlation ID in the no-op predicate so each deployment triggers reconciliation, even when the spec, image and synchronization hash are unchanged.

This replaces the synthetic completion event introduced in 786b92a8.